### PR TITLE
[docker] docker-compose 수정

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     build:
       context: ./core
       dockerfile: Dockerfile
+    depends_on:
+      - domain
     ports:
       - "8080:8080"
     networks:
@@ -14,7 +16,7 @@ services:
       context: ./chatting-api
       dockerfile: Dockerfile
     depends_on:
-      - core
+      - domain
     ports:
       - "8081:8081"
     networks:
@@ -25,11 +27,19 @@ services:
       context: ./streaming-api
       dockerfile: Dockerfile
     depends_on:
-      - core
+      - domain
     ports:
       - "8082:8082"
     networks:
       - viewtist
+
+  domain:
+    build:
+      context: ./domain
+      dockerfile: Dockerfile
+    networks:
+      - viewtist
+
 
 networks:
   viewtist:

--- a/domain/Dockerfile
+++ b/domain/Dockerfile
@@ -1,0 +1,4 @@
+FROM amazoncorretto:17
+ARG JAR_FILE=build/libs/*.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java", "-jar", "/app.jar"]


### PR DESCRIPTION
<!-- 제목은 ex) `[컨벤션] 제목` 으로 작성한다. ex) [feature] 결제 기능 -->

---

# 🌱 작업 사항

기존이랑 거의 비슷한대 core가 중심이었던걸 메인클래스가 없는 domain을 추가해 의존성 주입을 받게 설정했다.
그리고 domain에도 Dockerfile을 추가했다.
사실 메인클래스가 없어서 추가 안해도 되나싶어서 해봤지만 docker-compose가 돌아가지 않았다.
추가하니 별 이상 없이 돌아간다.

```
// DockerFile
FROM amazoncorretto:17
ARG JAR_FILE=build/libs/*.jar
COPY ${JAR_FILE} app.jar
ENTRYPOINT ["java", "-jar", "/app.jar"]

```

```
version: "3.8"
services:
  core:
    build:
      context: ./core
      dockerfile: Dockerfile
    depends_on:
      - domain
    ports:
      - "8080:8080"
    networks:
      - viewtist

  chatting-api:
    build:
      context: ./chatting-api
      dockerfile: Dockerfile
    depends_on:
      - domain
    ports:
      - "8081:8081"
    networks:
      - viewtist

  streaming-api:
    build:
      context: ./streaming-api
      dockerfile: Dockerfile
    depends_on:
      - domain
    ports:
      - "8082:8082"
    networks:
      - viewtist

  domain:
    build:
      context: ./domain
      dockerfile: Dockerfile
    networks:
      - viewtist


networks:
  viewtist:
```

---

# ❓ 리뷰 포인트

<!-- ex) service 로직 너무 뚱뚱해요 -->

---
모델 및 디비 관련은 도메인 모듈이 담당하도록 분리하였다. 따라서 모든 모듈이 도메인 모듈을 의존한다.
### 기존 모듈 관계
![image](https://github.com/redandsilver/puzzle/assets/129943670/b45ed43b-29b3-4567-af76-c12ba0aaf28d)

### 현재 모듈 관계
![image](https://github.com/redandsilver/puzzle/assets/129943670/e89f9bfc-82ca-4f30-9213-038a60681abe)

# 🦄 관련 이슈

<!-- ex) 테스트 어떤가요. -->


---
