### PR TITLE
[#36, #37, #38, #39] 스트리밍 기능 구현

### DIFF
--- a/domain/src/main/java/semicolon/viewtist/liveStreaming/dto/request/LiveStreamingCreateRequest.java
+++ b/domain/src/main/java/semicolon/viewtist/liveStreaming/dto/request/LiveStreamingCreateRequest.java
@@ -1,0 +1,27 @@
+package semicolon.viewtist.liveStreaming.dto.request;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+import semicolon.viewtist.liveStreaming.entity.Category;
+import semicolon.viewtist.liveStreaming.entity.LiveStreaming;
+import semicolon.viewtist.user.entity.User;
+
+@Getter
+@Setter
+public class LiveStreamingCreateRequest {
+
+  private String title;
+
+  private Category category;
+
+
+  public LiveStreaming from(LiveStreamingCreateRequest liveStreamingCreateRequest, User user) {
+    return LiveStreaming.builder()
+        .title(liveStreamingCreateRequest.getTitle())
+        .user(user)
+        .category(liveStreamingCreateRequest.getCategory())
+        .startAt(LocalDateTime.now())
+        .build();
+  }
+}

--- a/domain/src/main/java/semicolon/viewtist/liveStreaming/dto/request/LiveStreamingUpdateRequest.java
+++ b/domain/src/main/java/semicolon/viewtist/liveStreaming/dto/request/LiveStreamingUpdateRequest.java
@@ -1,0 +1,15 @@
+package semicolon.viewtist.liveStreaming.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+import semicolon.viewtist.liveStreaming.entity.Category;
+
+@Getter
+@Setter
+public class LiveStreamingUpdateRequest {
+
+  private String updateTitle;
+
+  private Category updateCategory;
+
+}

--- a/domain/src/main/java/semicolon/viewtist/liveStreaming/dto/response/LiveStreamingResponse.java
+++ b/domain/src/main/java/semicolon/viewtist/liveStreaming/dto/response/LiveStreamingResponse.java
@@ -1,0 +1,34 @@
+package semicolon.viewtist.liveStreaming.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import semicolon.viewtist.liveStreaming.entity.Category;
+import semicolon.viewtist.liveStreaming.entity.LiveStreaming;
+
+@Getter
+@Setter
+@Builder
+public class LiveStreamingResponse {
+
+  private String title;
+
+  private Category category;
+
+  private String streamerNickname;
+
+  private LocalDateTime startAt;
+
+  private Long viewerCount;
+
+
+  public static LiveStreamingResponse from(LiveStreaming liveStreaming) {
+    return LiveStreamingResponse.builder()
+        .title(liveStreaming.getTitle())
+        .streamerNickname(liveStreaming.getUser().getNickname())
+        .category(liveStreaming.getCategory())
+        .startAt(liveStreaming.getStartAt())
+        .build();
+  }
+}

--- a/domain/src/main/java/semicolon/viewtist/liveStreaming/entity/Category.java
+++ b/domain/src/main/java/semicolon/viewtist/liveStreaming/entity/Category.java
@@ -1,0 +1,6 @@
+package semicolon.viewtist.liveStreaming.entity;
+
+public enum Category {
+  MUSIC, DANCE, BOOK
+}
+

--- a/domain/src/main/java/semicolon/viewtist/liveStreaming/entity/LiveStreaming.java
+++ b/domain/src/main/java/semicolon/viewtist/liveStreaming/entity/LiveStreaming.java
@@ -1,0 +1,59 @@
+package semicolon.viewtist.liveStreaming.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import semicolon.viewtist.global.entitiy.BaseTimeEntity;
+import semicolon.viewtist.liveStreaming.dto.request.LiveStreamingUpdateRequest;
+import semicolon.viewtist.liveStreaming.dto.response.LiveStreamingResponse;
+import semicolon.viewtist.user.entity.User;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LiveStreaming extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @OneToOne
+  private User user;
+
+  @Column
+  private String title;
+
+  @Column
+  private Category category;
+
+  @Column
+  private LocalDateTime startAt;
+
+  @Column
+  private Long viewerCount;
+
+  public LiveStreamingResponse form(LiveStreaming liveStreaming) {
+    return LiveStreamingResponse.builder()
+        .title(liveStreaming.getTitle())
+        .streamerNickname(liveStreaming.getUser().getNickname())
+        .category(liveStreaming.getCategory())
+        .startAt(liveStreaming.getStartAt())
+        .viewerCount(liveStreaming.getViewerCount())
+        .build();
+  }
+
+  public void update(LiveStreamingUpdateRequest liveStreamingUpdateRequest) {
+    this.title = liveStreamingUpdateRequest.getUpdateTitle();
+    this.category = liveStreamingUpdateRequest.getUpdateCategory();
+  }
+}

--- a/domain/src/main/java/semicolon/viewtist/liveStreaming/exception/LiveStreamingException.java
+++ b/domain/src/main/java/semicolon/viewtist/liveStreaming/exception/LiveStreamingException.java
@@ -1,0 +1,15 @@
+package semicolon.viewtist.liveStreaming.exception;
+
+import semicolon.viewtist.global.exception.CustomException;
+import semicolon.viewtist.global.exception.ErrorCode;
+
+public class LiveStreamingException extends CustomException {
+
+  public LiveStreamingException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  public LiveStreamingException(ErrorCode errorCode, String msg) {
+    super(errorCode, msg);
+  }
+}

--- a/domain/src/main/java/semicolon/viewtist/liveStreaming/repository/LiveStreamingRepository.java
+++ b/domain/src/main/java/semicolon/viewtist/liveStreaming/repository/LiveStreamingRepository.java
@@ -1,0 +1,18 @@
+package semicolon.viewtist.liveStreaming.repository;
+
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import semicolon.viewtist.liveStreaming.entity.Category;
+import semicolon.viewtist.liveStreaming.entity.LiveStreaming;
+import semicolon.viewtist.user.entity.User;
+
+public interface LiveStreamingRepository extends JpaRepository<LiveStreaming, Long> {
+
+  Optional<LiveStreaming> findByUser(User user);
+
+  Page<LiveStreaming> findAllByOrderByViewerCountDesc(Pageable pageable);
+
+  Page<LiveStreaming> findAllByCategory(Category category, Pageable pageable);
+}

--- a/streaming-api/build.gradle
+++ b/streaming-api/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2")
 
 
 }

--- a/streaming-api/src/main/java/semicolon/viewtist/config/SecurityConfig.java
+++ b/streaming-api/src/main/java/semicolon/viewtist/config/SecurityConfig.java
@@ -1,0 +1,50 @@
+package semicolon.viewtist.config;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import semicolon.viewtist.jwt.AuthenticationFilter;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+public class SecurityConfig {
+
+  private final AuthenticationFilter authenticationFilter;
+
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http
+        .csrf(AbstractHttpConfigurer::disable)
+        .cors(Customizer.withDefaults())
+        .httpBasic(AbstractHttpConfigurer::disable)
+        .headers(c -> c.frameOptions(
+            HeadersConfigurer.FrameOptionsConfig::disable).disable())
+        .sessionManagement(c ->
+            c.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+        .authorizeHttpRequests((request) ->
+            request.requestMatchers(
+                    new AntPathRequestMatcher("/**")
+                ).permitAll()
+                .anyRequest().authenticated()
+        )
+
+        .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+    return http.build();
+  }
+}

--- a/streaming-api/src/main/java/semicolon/viewtist/config/SwaggerConfig.java
+++ b/streaming-api/src/main/java/semicolon/viewtist/config/SwaggerConfig.java
@@ -1,0 +1,20 @@
+package semicolon.viewtist.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI openAPI() {
+    Info info = new Info()
+        .title("Viewtist API Document")
+        .version("v0.0.1")
+        .description("뷰티스트 스트리밍 서비스 명세서입니다.");
+    return new OpenAPI()
+        .info(info);
+  }
+}

--- a/streaming-api/src/main/java/semicolon/viewtist/cotroller/LiveStreamingController.java
+++ b/streaming-api/src/main/java/semicolon/viewtist/cotroller/LiveStreamingController.java
@@ -1,0 +1,74 @@
+package semicolon.viewtist.cotroller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import semicolon.viewtist.liveStreaming.dto.request.LiveStreamingCreateRequest;
+import semicolon.viewtist.liveStreaming.dto.request.LiveStreamingUpdateRequest;
+import semicolon.viewtist.liveStreaming.dto.response.LiveStreamingResponse;
+import semicolon.viewtist.liveStreaming.entity.Category;
+import semicolon.viewtist.service.LiveStreamingService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/live-streaming")
+public class LiveStreamingController {
+
+  private final LiveStreamingService liveStreamingService;
+
+  @PreAuthorize("isAuthenticated()")
+  @PostMapping("/start")
+  public ResponseEntity<String> startLiveStreaming(
+      @RequestBody LiveStreamingCreateRequest liveStreamingCreateRequest,
+      Authentication authentication) {
+    liveStreamingService.startLiveStreaming(liveStreamingCreateRequest, authentication);
+    return ResponseEntity.ok("스트리밍이 시작되었습니다.");
+  }
+
+  @GetMapping("/{streamingId}")
+  public ResponseEntity<LiveStreamingResponse> liveStreamingPage(@PathVariable Long streamingId) {
+    return ResponseEntity.ok(liveStreamingService.liveStreamingPage(streamingId));
+  }
+
+  @PreAuthorize("isAuthenticated()")
+  @PutMapping("/update")
+  public ResponseEntity<String> updateLiveStreaming(
+      @RequestBody LiveStreamingUpdateRequest liveStreamingUpdateRequest,
+      Authentication authentication) {
+    liveStreamingService.updateLiveStreaming(liveStreamingUpdateRequest, authentication);
+    return ResponseEntity.ok("스트리밍이 업데이트 되었습니다.");
+  }
+
+  @PreAuthorize("isAuthenticated()")
+  @GetMapping("/stop")
+  public ResponseEntity<String> stopLiveStreaming(Authentication authentication) {
+    liveStreamingService.stopLiveStreaming(authentication);
+    return ResponseEntity.ok("스트리밍이 종료되었습니다.");
+  }
+
+  // 시청자 순으로
+  @GetMapping()
+  public Page<LiveStreamingResponse> getLiveStreamings(
+      Pageable pageable) {
+    return liveStreamingService.findLiveStreamings(pageable);
+  }
+
+  // 카테고리로 검색
+  @GetMapping("/category")
+  public Page<LiveStreamingResponse> findLiveStteamingsByCategory(@RequestBody Category category,
+      Pageable pageable) {
+    return liveStreamingService.findLiveStreamingsByCategory(category, pageable);
+  }
+
+
+}

--- a/streaming-api/src/main/java/semicolon/viewtist/cotroller/LiveStreamingController.java
+++ b/streaming-api/src/main/java/semicolon/viewtist/cotroller/LiveStreamingController.java
@@ -26,6 +26,7 @@ public class LiveStreamingController {
 
   private final LiveStreamingService liveStreamingService;
 
+  // 스트리밍 시작
   @PreAuthorize("isAuthenticated()")
   @PostMapping("/start")
   public ResponseEntity<String> startLiveStreaming(
@@ -35,11 +36,13 @@ public class LiveStreamingController {
     return ResponseEntity.ok("스트리밍이 시작되었습니다.");
   }
 
+  // 스트리밍 정보
   @GetMapping("/{streamingId}")
   public ResponseEntity<LiveStreamingResponse> liveStreamingPage(@PathVariable Long streamingId) {
     return ResponseEntity.ok(liveStreamingService.liveStreamingPage(streamingId));
   }
 
+  // 스트리밍 업데이트
   @PreAuthorize("isAuthenticated()")
   @PutMapping("/update")
   public ResponseEntity<String> updateLiveStreaming(
@@ -49,6 +52,7 @@ public class LiveStreamingController {
     return ResponseEntity.ok("스트리밍이 업데이트 되었습니다.");
   }
 
+  // 스트리밍 종료
   @PreAuthorize("isAuthenticated()")
   @GetMapping("/stop")
   public ResponseEntity<String> stopLiveStreaming(Authentication authentication) {
@@ -56,7 +60,7 @@ public class LiveStreamingController {
     return ResponseEntity.ok("스트리밍이 종료되었습니다.");
   }
 
-  // 시청자 순으로
+  // 스트리밍 나열 시청자 순으로
   @GetMapping()
   public Page<LiveStreamingResponse> getLiveStreamings(
       Pageable pageable) {

--- a/streaming-api/src/main/java/semicolon/viewtist/service/LiveStreamingService.java
+++ b/streaming-api/src/main/java/semicolon/viewtist/service/LiveStreamingService.java
@@ -1,0 +1,82 @@
+package semicolon.viewtist.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import semicolon.viewtist.global.exception.ErrorCode;
+import semicolon.viewtist.liveStreaming.dto.request.LiveStreamingCreateRequest;
+import semicolon.viewtist.liveStreaming.dto.request.LiveStreamingUpdateRequest;
+import semicolon.viewtist.liveStreaming.dto.response.LiveStreamingResponse;
+import semicolon.viewtist.liveStreaming.entity.Category;
+import semicolon.viewtist.liveStreaming.entity.LiveStreaming;
+import semicolon.viewtist.liveStreaming.exception.LiveStreamingException;
+import semicolon.viewtist.liveStreaming.repository.LiveStreamingRepository;
+import semicolon.viewtist.user.entity.User;
+import semicolon.viewtist.user.exception.UserException;
+import semicolon.viewtist.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class LiveStreamingService {
+
+  private final LiveStreamingRepository liveStreamingRepository;
+  private final UserRepository userRepository;
+
+  public void startLiveStreaming(LiveStreamingCreateRequest liveStreamingCreateRequest,
+      Authentication authentication) {
+
+    User user = findByEmailOrThrow(authentication);
+    LiveStreaming liveStreaming = liveStreamingCreateRequest.from(liveStreamingCreateRequest, user);
+    liveStreamingRepository.save(liveStreaming);
+  }
+
+  public LiveStreamingResponse liveStreamingPage(Long StreamingId) {
+
+    LiveStreaming liveStreaming = liveStreamingRepository.findById(StreamingId)
+        .orElseThrow(() -> new LiveStreamingException(ErrorCode.LIVE_STREAMING_NOT_FOUND));
+
+    return liveStreaming.form(liveStreaming);
+  }
+
+  public void updateLiveStreaming(
+      LiveStreamingUpdateRequest liveStreamingUpdateRequest,
+      Authentication authentication) {
+    User user = findByEmailOrThrow(authentication);
+
+    LiveStreaming liveStreaming = findLiveStreamingByUser(user);
+    liveStreaming.update(liveStreamingUpdateRequest);
+    liveStreamingRepository.save(liveStreaming);
+  }
+
+  public void stopLiveStreaming(Authentication authentication) {
+    User user = findByEmailOrThrow(authentication);
+    LiveStreaming liveStreaming = findLiveStreamingByUser(user);
+    liveStreamingRepository.delete(liveStreaming);
+  }
+
+  public Page<LiveStreamingResponse> findLiveStreamings(Pageable pageable) {
+    Page<LiveStreaming> liveStreamings = liveStreamingRepository.findAllByOrderByViewerCountDesc(
+        pageable);
+    return liveStreamings.map(LiveStreamingResponse::from);
+  }
+
+  public Page<LiveStreamingResponse> findLiveStreamingsByCategory(
+      Category category, Pageable pageable) {
+    Page<LiveStreaming> liveStreamings = liveStreamingRepository.findAllByCategory(category,
+        pageable);
+    return liveStreamings.map(LiveStreamingResponse::from);
+  }
+
+  private LiveStreaming findLiveStreamingByUser(User user) {
+    return liveStreamingRepository.findByUser(user)
+        .orElseThrow(() -> new LiveStreamingException(ErrorCode.LIVE_STREAMING_NOT_FOUND));
+  }
+
+  private User findByEmailOrThrow(Authentication authentication) {
+    return userRepository.findByEmail(authentication.getName())
+        .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+  }
+
+}


### PR DESCRIPTION
<!-- 제목은 ex) `[컨벤션] 제목` 으로 작성한다. ex) [feature] 결제 기능 -->

---

# 🌱 작업 사항

LiveStreaming Service 기능 구현 입니다.

스트리밍 시작할때 `LiveStreamingCreatRequest`와 `Authentication`로 파라미터를 받는다.
`Authentication`은 인증 정보를 담는 객체이다.
인증정보가 담긴 `Authentication`에서 user 정보를 데이터베이스에서 찾아서 가져온뒤 request 받은 값들로
`LiveStreaming` 데이터를 만들고 데이터베이스에 저장한다.
`LiveStreamingCreateRequest`는
제목, 카테고리 로 이루어져 있다.
```
public void startLiveStreaming(LiveStreamingCreateRequest liveStreamingCreateRequest,
      Authentication authentication) {

    User user = findByEmailOrThrow(authentication);
    LiveStreaming liveStreaming = liveStreamingCreateRequest.from(liveStreamingCreateRequest, user);
    liveStreamingRepository.save(liveStreaming);
  }

  public LiveStreamingResponse liveStreamingPage(Long StreamingId) {

    LiveStreaming liveStreaming = liveStreamingRepository.findById(StreamingId)
        .orElseThrow(() -> new LiveStreamingException(ErrorCode.LIVE_STREAMING_NOT_FOUND));

    return liveStreaming.form(liveStreaming);
  }
```

업데이트 하는 서비스 로직이다.
`LiveStreamingUpdateRequest` 와 `Authentication`을 파라미터로 받아
`Authentication`로 user 정보를 가져온 다음 유저가 만든 `LiveStreaming` 을 불러와서 데이터를 업데이트하는 방식이다.

```
  public void updateLiveStreaming(
      LiveStreamingUpdateRequest liveStreamingUpdateRequest,
      Authentication authentication) {
    User user = findByEmailOrThrow(authentication);

    LiveStreaming liveStreaming = findLiveStreamingByUser(user);
    liveStreaming.update(liveStreamingUpdateRequest);
    liveStreamingRepository.save(liveStreaming);
  }
```

스트리밍을 종료하는 서비스 로직이다.
`Authentication`을 파라미터로 가져온 다음 user 정보를 가져와서 user 가 하고 있는 방송을 종료하는 방식이다.

```

  public void stopLiveStreaming(Authentication authentication) {
    User user = findByEmailOrThrow(authentication);
    LiveStreaming liveStreaming = findLiveStreamingByUser(user);
    liveStreamingRepository.delete(liveStreaming);
  }
```
`페이징 기법(paging)`전체 데이터 중의 일부를 보여주는 방식을 사용하여 스트리밍중인 모든 방을 전부 보여주는 것이 아닌 일부만 보여주는 방식으로 구현했다.
방의 순서는 ViewerCount가 높은 순으로 정렬하게 구현했다.

```

  public Page<LiveStreamingResponse> findLiveStreamings(Pageable pageable) {
    Page<LiveStreaming> liveStreamings = liveStreamingRepository.findAllByOrderByViewerCountDesc(
        pageable);
    return liveStreamings.map(LiveStreamingResponse::from);
  }
  
```
다음은 카테고리로 스트리밍 방을 분류할 수 있게 구현했다. 이것 또한 페이징기법으로 구현했다. 

```

  public Page<LiveStreamingResponse> findLiveStreamingsByCategory(
      Category category, Pageable pageable) {
    Page<LiveStreaming> liveStreamings = liveStreamingRepository.findAllByCategory(category,
        pageable);
    return liveStreamings.map(LiveStreamingResponse::from);
  }

```

---

# ❓ 리뷰 포인트

코드에 부족한 부분이 없는지 리뷰해주세요

---

# 🦄 관련 이슈

테스트는 API로만 테스트 했습니다.

---