### PR TITLE
[#35] 스트리밍 시작 기능

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: [ "main","develop" ]
   pull_request:
-    branches: [ "main", "develop" ]
+    branches: [ "main" ]
 
 jobs:
   deploy:

--- a/domain/src/main/java/semicolon/viewtist/liveStreaming/dto/request/LiveStreamingCreateRequest.java
+++ b/domain/src/main/java/semicolon/viewtist/liveStreaming/dto/request/LiveStreamingCreateRequest.java
@@ -1,0 +1,27 @@
+package semicolon.viewtist.liveStreaming.dto.request;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.Setter;
+import semicolon.viewtist.liveStreaming.entity.Category;
+import semicolon.viewtist.liveStreaming.entity.LiveStreaming;
+import semicolon.viewtist.user.entity.User;
+
+@Getter
+@Setter
+public class LiveStreamingCreateRequest {
+
+  private String title;
+
+  private Category category;
+
+
+  public LiveStreaming from(LiveStreamingCreateRequest liveStreamingCreateRequest, User user) {
+    return LiveStreaming.builder()
+        .title(liveStreamingCreateRequest.getTitle())
+        .user(user)
+        .category(liveStreamingCreateRequest.getCategory())
+        .startAt(LocalDateTime.now())
+        .build();
+  }
+}

--- a/domain/src/main/java/semicolon/viewtist/liveStreaming/dto/request/LiveStreamingUpdateRequest.java
+++ b/domain/src/main/java/semicolon/viewtist/liveStreaming/dto/request/LiveStreamingUpdateRequest.java
@@ -1,0 +1,15 @@
+package semicolon.viewtist.liveStreaming.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+import semicolon.viewtist.liveStreaming.entity.Category;
+
+@Getter
+@Setter
+public class LiveStreamingUpdateRequest {
+
+  private String updateTitle;
+
+  private Category updateCategory;
+
+}

--- a/domain/src/main/java/semicolon/viewtist/liveStreaming/dto/response/LiveStreamingResponse.java
+++ b/domain/src/main/java/semicolon/viewtist/liveStreaming/dto/response/LiveStreamingResponse.java
@@ -1,0 +1,34 @@
+package semicolon.viewtist.liveStreaming.dto.response;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import semicolon.viewtist.liveStreaming.entity.Category;
+import semicolon.viewtist.liveStreaming.entity.LiveStreaming;
+
+@Getter
+@Setter
+@Builder
+public class LiveStreamingResponse {
+
+  private String title;
+
+  private Category category;
+
+  private String streamerNickname;
+
+  private LocalDateTime startAt;
+
+  private Long viewerCount;
+
+
+  public static LiveStreamingResponse from(LiveStreaming liveStreaming) {
+    return LiveStreamingResponse.builder()
+        .title(liveStreaming.getTitle())
+        .streamerNickname(liveStreaming.getUser().getNickname())
+        .category(liveStreaming.getCategory())
+        .startAt(liveStreaming.getStartAt())
+        .build();
+  }
+}

--- a/domain/src/main/java/semicolon/viewtist/liveStreaming/entity/Category.java
+++ b/domain/src/main/java/semicolon/viewtist/liveStreaming/entity/Category.java
@@ -1,0 +1,6 @@
+package semicolon.viewtist.liveStreaming.entity;
+
+public enum Category {
+  MUSIC, DANCE, BOOK
+}
+

--- a/domain/src/main/java/semicolon/viewtist/liveStreaming/entity/LiveStreaming.java
+++ b/domain/src/main/java/semicolon/viewtist/liveStreaming/entity/LiveStreaming.java
@@ -1,0 +1,59 @@
+package semicolon.viewtist.liveStreaming.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import semicolon.viewtist.global.entitiy.BaseTimeEntity;
+import semicolon.viewtist.liveStreaming.dto.request.LiveStreamingUpdateRequest;
+import semicolon.viewtist.liveStreaming.dto.response.LiveStreamingResponse;
+import semicolon.viewtist.user.entity.User;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LiveStreaming extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @OneToOne
+  private User user;
+
+  @Column
+  private String title;
+
+  @Column
+  private Category category;
+
+  @Column
+  private LocalDateTime startAt;
+
+  @Column
+  private Long viewerCount;
+
+  public LiveStreamingResponse form(LiveStreaming liveStreaming) {
+    return LiveStreamingResponse.builder()
+        .title(liveStreaming.getTitle())
+        .streamerNickname(liveStreaming.getUser().getNickname())
+        .category(liveStreaming.getCategory())
+        .startAt(liveStreaming.getStartAt())
+        .viewerCount(liveStreaming.getViewerCount())
+        .build();
+  }
+
+  public void update(LiveStreamingUpdateRequest liveStreamingUpdateRequest) {
+    this.title = liveStreamingUpdateRequest.getUpdateTitle();
+    this.category = liveStreamingUpdateRequest.getUpdateCategory();
+  }
+}

--- a/domain/src/main/java/semicolon/viewtist/liveStreaming/exception/LiveStreamingException.java
+++ b/domain/src/main/java/semicolon/viewtist/liveStreaming/exception/LiveStreamingException.java
@@ -1,0 +1,15 @@
+package semicolon.viewtist.liveStreaming.exception;
+
+import semicolon.viewtist.global.exception.CustomException;
+import semicolon.viewtist.global.exception.ErrorCode;
+
+public class LiveStreamingException extends CustomException {
+
+  public LiveStreamingException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  public LiveStreamingException(ErrorCode errorCode, String msg) {
+    super(errorCode, msg);
+  }
+}

--- a/domain/src/main/java/semicolon/viewtist/liveStreaming/repository/LiveStreamingRepository.java
+++ b/domain/src/main/java/semicolon/viewtist/liveStreaming/repository/LiveStreamingRepository.java
@@ -1,0 +1,18 @@
+package semicolon.viewtist.liveStreaming.repository;
+
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import semicolon.viewtist.liveStreaming.entity.Category;
+import semicolon.viewtist.liveStreaming.entity.LiveStreaming;
+import semicolon.viewtist.user.entity.User;
+
+public interface LiveStreamingRepository extends JpaRepository<LiveStreaming, Long> {
+
+  Optional<LiveStreaming> findByUser(User user);
+
+  Page<LiveStreaming> findAllByOrderByViewerCountDesc(Pageable pageable);
+
+  Page<LiveStreaming> findAllByCategory(Category category, Pageable pageable);
+}

--- a/streaming-api/build.gradle
+++ b/streaming-api/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2")
 
 
 }

--- a/streaming-api/src/main/java/semicolon/viewtist/config/SecurityConfig.java
+++ b/streaming-api/src/main/java/semicolon/viewtist/config/SecurityConfig.java
@@ -1,0 +1,50 @@
+package semicolon.viewtist.config;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import semicolon.viewtist.jwt.AuthenticationFilter;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+public class SecurityConfig {
+
+  private final AuthenticationFilter authenticationFilter;
+
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http
+        .csrf(AbstractHttpConfigurer::disable)
+        .cors(Customizer.withDefaults())
+        .httpBasic(AbstractHttpConfigurer::disable)
+        .headers(c -> c.frameOptions(
+            HeadersConfigurer.FrameOptionsConfig::disable).disable())
+        .sessionManagement(c ->
+            c.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+        .authorizeHttpRequests((request) ->
+            request.requestMatchers(
+                    new AntPathRequestMatcher("/**")
+                ).permitAll()
+                .anyRequest().authenticated()
+        )
+
+        .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+    return http.build();
+  }
+}

--- a/streaming-api/src/main/java/semicolon/viewtist/config/SwaggerConfig.java
+++ b/streaming-api/src/main/java/semicolon/viewtist/config/SwaggerConfig.java
@@ -1,0 +1,20 @@
+package semicolon.viewtist.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI openAPI() {
+    Info info = new Info()
+        .title("Viewtist API Document")
+        .version("v0.0.1")
+        .description("뷰티스트 스트리밍 서비스 명세서입니다.");
+    return new OpenAPI()
+        .info(info);
+  }
+}

--- a/streaming-api/src/main/java/semicolon/viewtist/cotroller/LiveStreamingController.java
+++ b/streaming-api/src/main/java/semicolon/viewtist/cotroller/LiveStreamingController.java
@@ -1,0 +1,32 @@
+package semicolon.viewtist.cotroller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import semicolon.viewtist.liveStreaming.dto.request.LiveStreamingCreateRequest;
+import semicolon.viewtist.service.LiveStreamingService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/live-streaming")
+public class LiveStreamingController {
+
+  private final LiveStreamingService liveStreamingService;
+
+  // 스트리밍 시작
+  @PreAuthorize("isAuthenticated()")
+  @PostMapping("/start")
+  public ResponseEntity<String> startLiveStreaming(
+      @RequestBody LiveStreamingCreateRequest liveStreamingCreateRequest,
+      Authentication authentication) {
+    liveStreamingService.startLiveStreaming(liveStreamingCreateRequest, authentication);
+    return ResponseEntity.ok("스트리밍이 시작되었습니다.");
+  }
+
+
+}

--- a/streaming-api/src/main/java/semicolon/viewtist/service/LiveStreamingService.java
+++ b/streaming-api/src/main/java/semicolon/viewtist/service/LiveStreamingService.java
@@ -1,0 +1,42 @@
+package semicolon.viewtist.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import semicolon.viewtist.global.exception.ErrorCode;
+import semicolon.viewtist.liveStreaming.dto.request.LiveStreamingCreateRequest;
+import semicolon.viewtist.liveStreaming.entity.LiveStreaming;
+import semicolon.viewtist.liveStreaming.exception.LiveStreamingException;
+import semicolon.viewtist.liveStreaming.repository.LiveStreamingRepository;
+import semicolon.viewtist.user.entity.User;
+import semicolon.viewtist.user.exception.UserException;
+import semicolon.viewtist.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class LiveStreamingService {
+
+  private final LiveStreamingRepository liveStreamingRepository;
+  private final UserRepository userRepository;
+
+  // 스트리밍 시작
+  public void startLiveStreaming(LiveStreamingCreateRequest liveStreamingCreateRequest,
+      Authentication authentication) {
+
+    User user = findByEmailOrThrow(authentication);
+    LiveStreaming liveStreaming = liveStreamingCreateRequest.from(liveStreamingCreateRequest, user);
+    liveStreamingRepository.save(liveStreaming);
+  }
+
+
+  private LiveStreaming findLiveStreamingByUser(User user) {
+    return liveStreamingRepository.findByUser(user)
+        .orElseThrow(() -> new LiveStreamingException(ErrorCode.LIVE_STREAMING_NOT_FOUND));
+  }
+
+  private User findByEmailOrThrow(Authentication authentication) {
+    return userRepository.findByEmail(authentication.getName())
+        .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+  }
+
+}


### PR DESCRIPTION
<!-- 제목은 ex) `[컨벤션] 제목` 으로 작성한다. ex) [feature] 결제 기능 -->

---

# 🌱 작업 사항

LiveStreaming Service 기능 구현 입니다.

스트리밍 시작할때 `LiveStreamingCreatRequest`와 `Authentication`로 파라미터를 받는다.
`Authentication`은 인증 정보를 담는 객체이다.
인증정보가 담긴 `Authentication`에서 user 정보를 데이터베이스에서 찾아서 가져온뒤 request 받은 값들로
`LiveStreaming` 데이터를 만들고 데이터베이스에 저장한다.
`LiveStreamingCreateRequest`는
제목, 카테고리 로 이루어져 있다.

```
public void startLiveStreaming(LiveStreamingCreateRequest liveStreamingCreateRequest,
      Authentication authentication) {

    User user = findByEmailOrThrow(authentication);
    LiveStreaming liveStreaming = liveStreamingCreateRequest.from(liveStreamingCreateRequest, user);
    liveStreamingRepository.save(liveStreaming);
  }

  public LiveStreamingResponse liveStreamingPage(Long StreamingId) {

    LiveStreaming liveStreaming = liveStreamingRepository.findById(StreamingId)
        .orElseThrow(() -> new LiveStreamingException(ErrorCode.LIVE_STREAMING_NOT_FOUND));

    return liveStreaming.form(liveStreaming);
  }
```

---

### ❓ 리뷰 포인트

<!-- ex) service 로직 너무 뚱뚱해요 -->

---

### 🦄 관련 이슈

<!-- ex) 테스트 어떤가요. -->

---
