### PR TITLE
[refactor] securityConfig && refreshToken 설정

### DIFF
--- a/common/src/main/java/semicolon/viewtist/config/SecurityConfig.java
+++ b/common/src/main/java/semicolon/viewtist/config/SecurityConfig.java
@@ -15,8 +15,9 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import semicolon.viewtist.jwt.AuthenticationFilter;
+import semicolon.viewtist.jwt.CustomAccessDeniedHandler;
+import semicolon.viewtist.jwt.CustomAuthenticationEntryPoint;
 import semicolon.viewtist.oauth.handler.OAuth2SuccessHandler;
 
 @RequiredArgsConstructor
@@ -25,6 +26,8 @@ import semicolon.viewtist.oauth.handler.OAuth2SuccessHandler;
 @EnableMethodSecurity
 public class SecurityConfig {
 
+  private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+  private final CustomAccessDeniedHandler customAccessDeniedHandler;
   private final OAuth2SuccessHandler oAuth2SuccessHandler;
   private final DefaultOAuth2UserService defaultOAuth2UserService;
   private final AuthenticationFilter authenticationFilter;
@@ -45,9 +48,9 @@ public class SecurityConfig {
         .sessionManagement(c ->
             c.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
-        .authorizeHttpRequests((request) ->
+        .authorizeHttpRequests(request ->
             request.requestMatchers(
-                    new AntPathRequestMatcher("/**")
+                    "/**"
                 ).permitAll()
                 .anyRequest().authenticated()
         )
@@ -56,6 +59,10 @@ public class SecurityConfig {
             .redirectionEndpoint(endpoint -> endpoint.baseUri("/oauth2/callback/*"))
             .userInfoEndpoint(endpoint -> endpoint.userService(defaultOAuth2UserService))
             .successHandler(oAuth2SuccessHandler)
+        )
+        .exceptionHandling(exception -> exception
+            .authenticationEntryPoint(customAuthenticationEntryPoint)
+            .accessDeniedHandler(customAccessDeniedHandler)
         )
 
         .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/common/src/main/java/semicolon/viewtist/config/SwaggerConfig.java
+++ b/common/src/main/java/semicolon/viewtist/config/SwaggerConfig.java
@@ -1,20 +1,39 @@
 package semicolon.viewtist.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityScheme.Type;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
-
   @Bean
   public OpenAPI openAPI() {
     Info info = new Info()
         .title("Viewtist API Document")
         .version("v0.0.1")
         .description("뷰티스트 유저서비스 명세서입니다.");
+
+    String jwtSchemeName = "jwtAuth";
+
+    SecurityRequirement securityRequirement = new SecurityRequirement()
+        .addList(jwtSchemeName);
+
+    Components components = new Components()
+        .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+            .name(jwtSchemeName)
+            .type(Type.HTTP)
+            .scheme("bearer")
+            .bearerFormat("JWT"));
+
     return new OpenAPI()
-        .info(info);
+        .info(info)
+        .components(components)
+        .addSecurityItem(securityRequirement);
   }
+
 }

--- a/common/src/main/java/semicolon/viewtist/oauth/handler/OAuth2SuccessHandler.java
+++ b/common/src/main/java/semicolon/viewtist/oauth/handler/OAuth2SuccessHandler.java
@@ -32,12 +32,18 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     User user = userRepository.findByNickname(userId)
         .orElseThrow(() -> new UserException(USER_NOT_FOUND));
 
-    String token = tokenProvider.generateToken(user);
+    String accessToken = tokenProvider.generateToken(user);
+    String refreshToken = tokenProvider.generateRefreshToken(user);
+
+    user.setRefreshToken(refreshToken);
+    userRepository.save(user);
+
     response.setContentType("application/json");
     response.setCharacterEncoding("UTF-8");
 
     JSONObject jsonResponse = new JSONObject();
-    jsonResponse.put("token", token);
+    jsonResponse.put("accessToken", accessToken);
+    jsonResponse.put("refreshToken", refreshToken);
 
     response.getWriter().write(jsonResponse.toString());
   }

--- a/common/src/main/java/semicolon/viewtist/user/controller/AuthController.java
+++ b/common/src/main/java/semicolon/viewtist/user/controller/AuthController.java
@@ -1,8 +1,8 @@
 package semicolon.viewtist.user.controller;
 
 
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.io.IOException;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -63,12 +63,11 @@ public class AuthController {
   }
 
   // 토큰 재발급
-  @PreAuthorize("isAuthenticated()")
+  @ApiResponse(responseCode = "200", description = "새로운 accessToken")
   @PostMapping("/refresh-token")
-  public ResponseEntity<Map<String, String>> refreshToken(
-      @RequestHeader("Authorization") String refreshToken) {
-    String newToken = authService.refreshToken(refreshToken);
-    Map<String, String> response = Map.of("accessToken", newToken);
+  public ResponseEntity<String> refreshToken(@RequestHeader("Authorization") String accessToken,
+      @RequestBody String refreshToken) {
+    String response = authService.refreshToken(accessToken, refreshToken);
     return ResponseEntity.ok(response);
   }
 

--- a/common/src/main/java/semicolon/viewtist/user/controller/AuthController.java
+++ b/common/src/main/java/semicolon/viewtist/user/controller/AuthController.java
@@ -13,8 +13,9 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import semicolon.viewtist.user.dto.request.UserSignupRequest;
 import semicolon.viewtist.user.dto.request.UserSigninRequest;
+import semicolon.viewtist.user.dto.request.UserSignupRequest;
+import semicolon.viewtist.user.dto.response.SigninResponse;
 import semicolon.viewtist.user.service.AuthService;
 
 
@@ -48,9 +49,8 @@ public class AuthController {
 
   // 로그인
   @PostMapping("/signin")
-  public ResponseEntity<Map<String, String>> signin(@RequestBody UserSigninRequest request) {
-    String token = authService.signin(request);
-    Map<String, String> response = Map.of("token", token);
+  public ResponseEntity<SigninResponse> signin(@RequestBody UserSigninRequest request) {
+    SigninResponse response = authService.signin(request);
     return ResponseEntity.ok(response);
   }
 
@@ -66,11 +66,10 @@ public class AuthController {
   @PreAuthorize("isAuthenticated()")
   @PostMapping("/refresh-token")
   public ResponseEntity<Map<String, String>> refreshToken(
-      @RequestHeader("Authorization") String token) {
-    String newToken = authService.refreshToken(token);
-    Map<String, String> response = Map.of("token", newToken);
+      @RequestHeader("Authorization") String refreshToken) {
+    String newToken = authService.refreshToken(refreshToken);
+    Map<String, String> response = Map.of("accessToken", newToken);
     return ResponseEntity.ok(response);
   }
-
 
 }

--- a/common/src/main/java/semicolon/viewtist/user/controller/UserController.java
+++ b/common/src/main/java/semicolon/viewtist/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package semicolon.viewtist.user.controller;
 
 import java.io.IOException;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import semicolon.viewtist.s3.S3UploaderService;
+import semicolon.viewtist.user.dto.request.UpdateMypage;
 import semicolon.viewtist.user.dto.request.UpdatePasswordRequest;
 import semicolon.viewtist.user.dto.response.UserResponse;
 import semicolon.viewtist.user.service.UserService;
@@ -34,15 +36,6 @@ public class UserController {
     return ResponseEntity.ok(userService.userDetail(authentication));
   }
 
-  // 프로필 사진 변경
-  @PreAuthorize("isAuthenticated()")
-  @PutMapping("/profile-photo")
-  public ResponseEntity<String> updateProfilePhoto(@RequestParam("file") MultipartFile file,
-      Authentication authentication)
-      throws IOException {
-    userService.updateProfilePhoto(file, authentication);
-    return ResponseEntity.ok("프로필 사진이 변경되었습니다.");
-  }
 
   // 비밀번호 찾기
   @PostMapping("/find-password")
@@ -60,21 +53,44 @@ public class UserController {
     return ResponseEntity.ok("비밀번호가 변경되었습니다.");
   }
 
-  // 닉네임 변경
+//  @PostMapping("/upload")
+//  public ResponseEntity<String> uploadPhoto(@RequestParam("file") MultipartFile file)
+//      throws IOException {
+//    s3UploaderService.uploadImage(file);
+//    return ResponseEntity.ok("사진이 업로드 되었습니다.");
+//  }
+
   @PreAuthorize("isAuthenticated()")
-  @PutMapping("/update-nickname")
-  public ResponseEntity<String> updateNickname(@RequestBody String nickname,
+  @PutMapping("/update-profile-photo")
+  public ResponseEntity<Map<String, String>> updateProfilePhoto(
+      @RequestParam("file") MultipartFile file,
+      Authentication authentication) throws IOException {
+    String photoUrl = userService.updateProfilePhoto(file, authentication);
+    Map<String, String> response = Map.of("profilePhotoUrl", photoUrl);
+    return ResponseEntity.ok(response);
+  }
+
+  @PreAuthorize("isAuthenticated()")
+  @PutMapping("/update-mypage")
+  public ResponseEntity<String> updateMypage(@RequestBody UpdateMypage updateMypage,
       Authentication authentication) {
-    userService.updateNickname(nickname, authentication);
-    return ResponseEntity.ok("닉네임이 변경되었습니다.");
+    userService.updateUserProfile(updateMypage.getNickname(),
+        updateMypage.getChannelIntroduction(), authentication);
+    return ResponseEntity.ok("채널관리가 수정되었습니다.");
   }
 
-  @PostMapping("/upload")
-  public ResponseEntity<String> uploadPhoto(@RequestParam("file") MultipartFile file)
-      throws IOException {
-    s3UploaderService.uploadImage(file);
-    return ResponseEntity.ok("사진이 업로드 되었습니다.");
+  @PreAuthorize("isAuthenticated()")
+  @GetMapping("/stream-key")
+  public ResponseEntity<Map<String, String>> getStreamKey(Authentication authentication) {
+    String streamKey = userService.getStreamKey(authentication);
+    return ResponseEntity.ok(Map.of("streamKey", streamKey));
   }
 
+  @PreAuthorize("isAuthenticated()")
+  @GetMapping("/refresh-stream-key")
+  public ResponseEntity<Map<String, String>> refreshStreamKey(Authentication authentication) {
+    String newStreamKey = userService.refreshStreamKey(authentication);
+    return ResponseEntity.ok(Map.of("streamKey", newStreamKey));
+  }
 }
 

--- a/common/src/main/java/semicolon/viewtist/user/controller/UserController.java
+++ b/common/src/main/java/semicolon/viewtist/user/controller/UserController.java
@@ -1,8 +1,10 @@
 package semicolon.viewtist.user.controller;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import java.io.IOException;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
@@ -11,7 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import semicolon.viewtist.s3.S3UploaderService;
@@ -61,13 +63,15 @@ public class UserController {
 //  }
 
   @PreAuthorize("isAuthenticated()")
-  @PutMapping("/update-profile-photo")
-  public ResponseEntity<Map<String, String>> updateProfilePhoto(
-      @RequestParam("file") MultipartFile file,
+  @PutMapping(value ="/update-profile-photo",
+      consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<String> updateProfilePhoto(@Parameter(
+      description = "multipart/form-data 형식의 이미지 리스트를 input으로 받습니다. 이때 key 값은 multipartFile 입니다."
+  )
+      @RequestPart("file") MultipartFile file,
       Authentication authentication) throws IOException {
     String photoUrl = userService.updateProfilePhoto(file, authentication);
-    Map<String, String> response = Map.of("profilePhotoUrl", photoUrl);
-    return ResponseEntity.ok(response);
+    return ResponseEntity.ok(photoUrl);
   }
 
   @PreAuthorize("isAuthenticated()")

--- a/common/src/main/java/semicolon/viewtist/user/service/AuthService.java
+++ b/common/src/main/java/semicolon/viewtist/user/service/AuthService.java
@@ -2,7 +2,6 @@ package semicolon.viewtist.user.service;
 
 import static semicolon.viewtist.global.exception.ErrorCode.ALREADY_EXISTS_EMAIL;
 import static semicolon.viewtist.global.exception.ErrorCode.ALREADY_EXISTS_NICKNAME;
-import static semicolon.viewtist.global.exception.ErrorCode.EMAIL_NOT_FOUND;
 import static semicolon.viewtist.global.exception.ErrorCode.INVALID_TOKEN;
 import static semicolon.viewtist.global.exception.ErrorCode.NOT_VERIFIED_EMAIL;
 import static semicolon.viewtist.global.exception.ErrorCode.PASSWORDS_NOT_MATCH;
@@ -11,7 +10,6 @@ import static semicolon.viewtist.global.exception.ErrorCode.USER_NOT_FOUND;
 import static semicolon.viewtist.global.exception.ErrorCode.VERIFY_YOUR_EMAIL;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,12 +21,14 @@ import semicolon.viewtist.jwt.entity.TokenBlacklist;
 import semicolon.viewtist.jwt.repository.TokenBlacklistRepository;
 import semicolon.viewtist.mailgun.MailgunClient;
 import semicolon.viewtist.mailgun.SendMailForm;
-import semicolon.viewtist.user.dto.request.UserSignupRequest;
 import semicolon.viewtist.user.dto.request.UserSigninRequest;
+import semicolon.viewtist.user.dto.request.UserSignupRequest;
+import semicolon.viewtist.user.dto.response.SigninResponse;
 import semicolon.viewtist.user.entity.Type;
 import semicolon.viewtist.user.entity.User;
 import semicolon.viewtist.user.exception.UserException;
 import semicolon.viewtist.user.repository.UserRepository;
+
 
 @Service
 @RequiredArgsConstructor
@@ -51,8 +51,7 @@ public class AuthService {
   // 회원가입
   @Transactional
   public void signup(UserSignupRequest request) {
-    User user = userRepository.findByEmail(request.getEmail())
-        .orElseThrow(() -> new UserException(USER_NOT_FOUND));
+    User user = findUserByEmail(request.getEmail());
 
     if (userRepository.existsByNickname(request.getNickname())) {
       throw new UserException(ALREADY_EXISTS_NICKNAME);
@@ -68,33 +67,26 @@ public class AuthService {
     userRepository.save(user);
   }
 
-
-  // 인증 이메일 발송
   public void sendEmail(String email) {
     String token = UUID.randomUUID().toString();
     LocalDateTime tokenExpiryAt = LocalDateTime.now().plusMinutes(3);
 
-    Optional<User> optionalUser = userRepository.findByEmail(email);
-    if (optionalUser.isPresent()) {
-      User user = optionalUser.get();
-      user.setToken(token, tokenExpiryAt);
-      userRepository.save(user);
-      if (user.isEmailVerified()) {
-        throw new UserException(ALREADY_EXISTS_EMAIL);
-      } else {
-        user.setToken(token, tokenExpiryAt);
-        userRepository.save(user);
-      }
-    } else {
-      User user = User.builder()
-          .email(email)
-          .isEmailVerified(false)
-          .emailVerificationToken(token)
-          .tokenExpiryAt(tokenExpiryAt)
-          .type(Type.local)
-          .build();
-      userRepository.save(user);
+    User user = userRepository.findByEmail(email).orElseGet(() -> User.builder()
+        .email(email)
+        .isEmailVerified(false)
+        .emailVerificationToken(token)
+        .tokenExpiryAt(tokenExpiryAt)
+        .type(Type.local)
+        .streamKey(UUID.randomUUID().toString())
+        .channelIntroduction("채널을 소개해 주세요")
+        .build());
+
+    if (user.isEmailVerified()) {
+      throw new UserException(ALREADY_EXISTS_EMAIL);
     }
+
+    user.setToken(token, tokenExpiryAt);
+    userRepository.save(user);
 
     String verificationLink = verifiedUrl + token;
     SendMailForm sendMailForm = SendMailForm.builder().from(from)
@@ -105,59 +97,101 @@ public class AuthService {
     mailgunClient.sendEmail(sendMailForm);
   }
 
-  // 이메일 인증
   @Transactional
   public void verifyEmailToken(String token) {
     User user = userRepository.findByEmailVerificationToken(token)
         .orElseThrow(() -> new UserException(USER_NOT_FOUND));
 
     if (user.getTokenExpiryAt().isBefore(LocalDateTime.now())) {
-      throw new UserException(TIME_OUT_INVALID_TOKEN); // 만료된 토큰일 경우 예외 발생
+      throw new UserException(TIME_OUT_INVALID_TOKEN);
     }
 
-    if (!(user.getEmailVerificationToken().equals(token))) {
-      throw new UserException(INVALID_TOKEN); // 유효하지 않은 토큰일 경우 예외 발생
-    }
-
-    user.setEmailVerified(true, null); // 이메일 인증 상태를 true로 변경
+    user.setEmailVerified(true, null);
     userRepository.save(user);
   }
 
   // 로그인
-  public String signin(UserSigninRequest request) {
-    User user = userRepository.findByEmail(request.getEmail())
-        .orElseThrow(() -> new UserException(EMAIL_NOT_FOUND));
+  public SigninResponse signin(UserSigninRequest request) {
+    User user = findUserByEmail(request.getEmail());
 
-    if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-      throw new UserException(PASSWORDS_NOT_MATCH);
-    }
+    validateUserCredentials(request.getPassword(), user);
 
+    // 액세스 토큰 및 리프레시 토큰 생성 및 저장
+    String accessToken = tokenProvider.generateToken(user);
+    String refreshToken = generateAndPersistRefreshToken(user);
 
-    if (!user.isEmailVerified()) {
-      throw new UserException(VERIFY_YOUR_EMAIL);
-    }
-
-    return tokenProvider.generateToken(user);
+    return new SigninResponse(accessToken, refreshToken);
   }
 
   // 로그아웃
   public void signout(String token) {
-    addTokenBlacklist(token);
+    String email = extractEmailFromToken(token);
+    User user = findUserByEmail(email);
+
+    invalidateTokens(token, user);
   }
 
   // 토큰 재발급
-  public String refreshToken(String token) {
+  @Transactional
+  public String refreshToken(String refreshToken) {
+    String email = extractEmailFromToken(refreshToken);
+    User user = findUserByEmail(email);
 
-    addTokenBlacklist(token);
+    validateRefreshToken(user);
 
-    return tokenProvider.refreshToken(token.substring(7));
+    return tokenProvider.generateToken(user);
   }
 
-  private void addTokenBlacklist(String token) {
+  private User findUserByEmail(String email) {
+    return userRepository.findByEmail(email)
+        .orElseThrow(() -> new UserException(USER_NOT_FOUND));
+  }
 
+  // 유저 비밀번호, 이메일 맞는지
+  private void validateUserCredentials(String rawPassword, User user) {
+    if (!passwordEncoder.matches(rawPassword, user.getPassword())) {
+      throw new UserException(PASSWORDS_NOT_MATCH);
+    }
+    if (!user.isEmailVerified()) {
+      throw new UserException(VERIFY_YOUR_EMAIL);
+    }
+  }
+
+  // 리프레시 토큰 생성 및 저장
+  private String generateAndPersistRefreshToken(User user) {
+    String refreshToken = tokenProvider.generateRefreshToken(user);
+    user.setRefreshToken(refreshToken);
+    userRepository.save(user);
+    return refreshToken;
+  }
+
+  // 토큰 블랙리스트 추가 및 액세스 토큰 삭제 및 리프레시
+  private void invalidateTokens(String token, User user) {
+    addTokenBlacklist(user.getRefreshToken());
+    addTokenBlacklist(token);
+  }
+
+  // 토큰에서 유저 아이디 추출(유저 아이디 사용하여 유저 정보 조회)
+  private String extractEmailFromToken(String token) {
+    return tokenProvider.getUserIdFromToken(token.substring(7));
+  }
+
+  // 리프레시 토큰 유효성 검사(토큰 유효성 검사)
+  private void validateRefreshToken(User user) {
+    String storedRefreshToken = user.getRefreshToken();
+    if (!tokenProvider.validateToken(storedRefreshToken)) {
+      throw new UserException(INVALID_TOKEN);
+    }
+  }
+
+  // 토큰 블랙리스트 추가
+  private void addTokenBlacklist(String token) {
     TokenBlacklist tokenBlacklist = new TokenBlacklist(token.substring(7));
     tokenBlacklistRepository.save(tokenBlacklist);
   }
+
+
 }
+
 
 

--- a/common/src/main/java/semicolon/viewtist/user/service/AuthService.java
+++ b/common/src/main/java/semicolon/viewtist/user/service/AuthService.java
@@ -61,9 +61,9 @@ public class AuthService {
       throw new UserException(NOT_VERIFIED_EMAIL);
     }
 
-    user.setNickname(request.getNickname());
-    user.setPassword(passwordEncoder.encode(request.getPassword()));
-    user.setProfilePhotoUrl(request.getProfilePhotoUrl());
+    user.setSignup(request.getNickname(), passwordEncoder.encode(request.getPassword()),
+        request.getProfilePhotoUrl());
+
     userRepository.save(user);
   }
 

--- a/common/src/main/java/semicolon/viewtist/user/service/UserService.java
+++ b/common/src/main/java/semicolon/viewtist/user/service/UserService.java
@@ -54,7 +54,7 @@ public class UserService {
 
   // 프로필 사진 변경
   @Transactional
-  public void updateProfilePhoto(MultipartFile newImageFile, Authentication authentication)
+  public String updateProfilePhoto(MultipartFile newImageFile, Authentication authentication)
       throws IOException {
     User user = findByEmailOrThrow(authentication.getName());
 
@@ -76,6 +76,7 @@ public class UserService {
     // 사용자 정보에 새로운 프로필 사진 URL 업데이트
     user.setProfilePhotoUrl(newImageUrl);
     userRepository.save(user);
+    return newImageUrl;
   }
 
   // 비밀번호 찾기
@@ -124,16 +125,34 @@ public class UserService {
 
   // 유저 닉네임 수정
   @Transactional
-  public void updateNickname(String nickname, Authentication authentication) {
+  public void updateUserProfile(String nickname, String introduction,
+      Authentication authentication) {
     User user = findByEmailOrThrow(authentication.getName());
+
     // 닉네임 중복 확인
     if (userRepository.existsByNickname(nickname)) {
       throw new UserException(ALREADY_EXISTS_NICKNAME);
-    } else {
-      user.setNickname(nickname);
     }
+
+    // 닉네임과 소개글 업데이트
+    user.setUpdateUserProfile(nickname, introduction);
+
     userRepository.save(user);
   }
 
+  // 스트림키 가져오기
+  public String getStreamKey(Authentication authentication) {
+    User user = findByEmailOrThrow(authentication.getName());
+    return user.getStreamKey();
+  }
+
+  // 새로운 스트림키 생성
+  @Transactional
+  public String refreshStreamKey(Authentication authentication) {
+    User user = findByEmailOrThrow(authentication.getName());
+    user.setStreamKey(UUID.randomUUID().toString());
+    userRepository.save(user); // 새로운 스트림 키 생성 후 저장
+    return user.getStreamKey();
+  }
 
 }

--- a/domain/src/main/java/semicolon/viewtist/global/exception/ErrorCode.java
+++ b/domain/src/main/java/semicolon/viewtist/global/exception/ErrorCode.java
@@ -1,7 +1,9 @@
 package semicolon.viewtist.global.exception;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -18,9 +20,13 @@ public enum ErrorCode {
   EMAIL_NOT_FOUND(NOT_FOUND, "존재하지 않는 회원입니다."),
   PASSWORDS_NOT_MATCH(BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
   VERIFY_YOUR_EMAIL(BAD_REQUEST, "이메일 인증이 필요합니다."),
-  INVALID_TOKEN(BAD_REQUEST, "유효하지 않은 토큰입니다."),
+  INVALID_TOKEN(UNAUTHORIZED, "유효하지 않은 토큰입니다."),
   TIME_OUT_INVALID_TOKEN(BAD_REQUEST, "인증시간이 만료되었습니다."),
   NOT_VERIFIED_EMAIL(BAD_REQUEST, "이메일 인증을 진행해 주세요."),
+
+  SECURITY_UNAUTHORIZED(FORBIDDEN, "승인 실패"),
+  ACCESS_DENIED(UNAUTHORIZED, "접근 실패"),
+
 
   // s3
   S3_FILE_CONVERT_ERROR(BAD_REQUEST, "S3 파일변환 에러입니다."),

--- a/domain/src/main/java/semicolon/viewtist/jwt/CustomAccessDeniedHandler.java
+++ b/domain/src/main/java/semicolon/viewtist/jwt/CustomAccessDeniedHandler.java
@@ -1,0 +1,35 @@
+package semicolon.viewtist.jwt;
+
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+import static semicolon.viewtist.global.exception.ErrorCode.ACCESS_DENIED;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import semicolon.viewtist.global.exception.ErrorResponse;
+
+@Slf4j
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Override
+  public void handle(HttpServletRequest request, HttpServletResponse response,
+      AccessDeniedException accessDeniedException) throws IOException, ServletException {
+    ErrorResponse errorResponse = new ErrorResponse(ACCESS_DENIED,
+        ACCESS_DENIED.getMessage());
+
+    log.error("{} is occurred in CustomAccessDeniedHandler", errorResponse.errorCode());
+
+    response.setStatus(UNAUTHORIZED.value());
+    response.setContentType("application/json;charset=utf-8");
+    response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+  }
+}

--- a/domain/src/main/java/semicolon/viewtist/jwt/CustomAuthenticationEntryPoint.java
+++ b/domain/src/main/java/semicolon/viewtist/jwt/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,35 @@
+package semicolon.viewtist.jwt;
+
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+import static semicolon.viewtist.global.exception.ErrorCode.SECURITY_UNAUTHORIZED;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import semicolon.viewtist.global.exception.ErrorResponse;
+
+@Slf4j
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Override
+  public void commence(HttpServletRequest request, HttpServletResponse response,
+      AuthenticationException authException) throws IOException, ServletException {
+    ErrorResponse errorResponse = new ErrorResponse(SECURITY_UNAUTHORIZED,
+        SECURITY_UNAUTHORIZED.getMessage());
+
+    log.error("{} is occurred in CustomAuthenticationEntryPoint", errorResponse.errorCode());
+
+    response.setStatus(UNAUTHORIZED.value());
+    response.setContentType("application/json;charset=utf-8");
+    response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+  }
+}

--- a/domain/src/main/java/semicolon/viewtist/jwt/TokenProvider.java
+++ b/domain/src/main/java/semicolon/viewtist/jwt/TokenProvider.java
@@ -1,12 +1,8 @@
 package semicolon.viewtist.jwt;
 
 
-import static semicolon.viewtist.global.exception.ErrorCode.EMAIL_NOT_FOUND;
-import static semicolon.viewtist.global.exception.ErrorCode.INVALID_TOKEN;
-
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -23,15 +19,14 @@ import org.springframework.util.StringUtils;
 import semicolon.viewtist.global.exception.ErrorCode;
 import semicolon.viewtist.user.entity.User;
 import semicolon.viewtist.user.exception.UserException;
-import semicolon.viewtist.user.repository.UserRepository;
 
 
 @RequiredArgsConstructor
 @Component
 public class TokenProvider {
 
-  private static final long TOKEN_EXPIRE_TIME = 1000 * 60 * 60; // 1시간
-  private final UserRepository userRepository;
+  private static final long TOKEN_EXPIRE_TIME = 1000 * 60 * 60; // 24시간
+  private static final long REFRESH_TOKEN_EXPIRE_TIME = TOKEN_EXPIRE_TIME * 24; // 24시간
 
   @Value("${spring.jwt.key}")
   private String key;
@@ -88,17 +83,22 @@ public class TokenProvider {
     }
   }
 
-  public String refreshToken(String token) {
-    if (validateToken(token)) {
-      Jws<Claims> claims = Jwts.parserBuilder().setSigningKey(secretKey).build()
-          .parseClaimsJws(token);
-      String userEmail = claims.getBody().getSubject();
-      User user = userRepository.findByEmail(userEmail)
-          .orElseThrow(() -> new UserException(EMAIL_NOT_FOUND));
-      return generateToken(user);
-    } else {
-      throw new UserException(INVALID_TOKEN);
-    }
+  // 리프레시 토큰 생성
+  public String generateRefreshToken(User user) {
+    Date now = new Date();
+    Date expiredDate = new Date(now.getTime() + REFRESH_TOKEN_EXPIRE_TIME);
+
+    return Jwts.builder()
+        .setSubject(user.getEmail())
+        .setIssuedAt(now)
+        .setExpiration(expiredDate)
+        .signWith(secretKey, SignatureAlgorithm.HS256)
+        .compact();
   }
 
+  // 토큰에서 유저 아이디 추출(유저 아이디 사용하여 유저 정보 조회)
+  public String getUserIdFromToken(String token) {
+    Claims claims = parseClaims(token);
+    return claims.getSubject();
+  }
 }

--- a/domain/src/main/java/semicolon/viewtist/jwt/TokenProvider.java
+++ b/domain/src/main/java/semicolon/viewtist/jwt/TokenProvider.java
@@ -25,7 +25,7 @@ import semicolon.viewtist.user.exception.UserException;
 @Component
 public class TokenProvider {
 
-  private static final long TOKEN_EXPIRE_TIME = 1000 * 60 * 60; // 24시간
+  private static final long TOKEN_EXPIRE_TIME = 1000 * 60; // 1분
   private static final long REFRESH_TOKEN_EXPIRE_TIME = TOKEN_EXPIRE_TIME * 24; // 24시간
 
   @Value("${spring.jwt.key}")

--- a/domain/src/main/java/semicolon/viewtist/user/dto/request/SocialUserRequest.java
+++ b/domain/src/main/java/semicolon/viewtist/user/dto/request/SocialUserRequest.java
@@ -1,5 +1,6 @@
 package semicolon.viewtist.user.dto.request;
 
+import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
@@ -24,6 +25,8 @@ public class SocialUserRequest {
         .email(socialUserRequest.email)
         .password("******")
         .isEmailVerified(true)
+        .streamKey(UUID.randomUUID().toString())
+        .channelIntroduction("채널을 소개해 주세요")
         .build();
   }
 }

--- a/domain/src/main/java/semicolon/viewtist/user/dto/request/UpdateMypage.java
+++ b/domain/src/main/java/semicolon/viewtist/user/dto/request/UpdateMypage.java
@@ -1,0 +1,21 @@
+package semicolon.viewtist.user.dto.request;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateMypage {
+
+  @NotBlank(message = "닉네임을 입력해 주세요.")
+  private String nickname;
+
+  @NotBlank(message = "채널 소개를 적어주세요")
+  private String channelIntroduction;
+
+}

--- a/domain/src/main/java/semicolon/viewtist/user/dto/response/SigninResponse.java
+++ b/domain/src/main/java/semicolon/viewtist/user/dto/response/SigninResponse.java
@@ -1,0 +1,17 @@
+package semicolon.viewtist.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SigninResponse {
+
+  private String accessToken;
+  private String refreshToken;
+
+}

--- a/domain/src/main/java/semicolon/viewtist/user/dto/response/UserResponse.java
+++ b/domain/src/main/java/semicolon/viewtist/user/dto/response/UserResponse.java
@@ -18,6 +18,8 @@ public class UserResponse {
 
   private Long accountId;
 
+  private String channelIntroduction;
+
 
   public static UserResponse from(User user) {
 

--- a/domain/src/main/java/semicolon/viewtist/user/dto/response/UserResponse.java
+++ b/domain/src/main/java/semicolon/viewtist/user/dto/response/UserResponse.java
@@ -28,6 +28,7 @@ public class UserResponse {
         .nickname(user.getNickname())
         .profilePhotoUrl(user.getProfilePhotoUrl())
         .accountId(user.getAccountId())
+        .channelIntroduction(user.getChannelIntroduction())
         .build();
   }
 }

--- a/domain/src/main/java/semicolon/viewtist/user/entity/User.java
+++ b/domain/src/main/java/semicolon/viewtist/user/entity/User.java
@@ -70,13 +70,6 @@ public class User extends BaseTimeEntity {
     this.profilePhotoUrl = newImageUrl;
   }
 
-  public void setPassword(String encode) {
-    this.password = encode;
-  }
-
-  public void setNickname(String nickname) {
-    this.nickname = nickname;
-  }
 
   public void setToken(String token, LocalDateTime tokenExpiryAt) {
     this.emailVerificationToken = token;
@@ -85,5 +78,24 @@ public class User extends BaseTimeEntity {
 
   public void setRefreshToken(String refreshToken) {
     this.refreshToken = refreshToken;
+  }
+
+  public void setStreamKey(String streamKey) {
+    this.streamKey = streamKey;
+  }
+
+  public void setSignup(String nickname, String password, String profilePhotoUrl) {
+    this.nickname = nickname;
+    this.password = password;
+    this.profilePhotoUrl = profilePhotoUrl;
+  }
+
+  public void setUpdateUserProfile(String nickname, String introduction) {
+    this.nickname = nickname;
+    this.channelIntroduction = introduction;
+  }
+
+  public void setPassword(String password) {
+    this.password = password;
   }
 }

--- a/domain/src/main/java/semicolon/viewtist/user/entity/User.java
+++ b/domain/src/main/java/semicolon/viewtist/user/entity/User.java
@@ -51,6 +51,15 @@ public class User extends BaseTimeEntity {
   @Column
   private LocalDateTime tokenExpiryAt;
 
+  @Column
+  private String refreshToken;
+
+  @Column
+  private String streamKey;
+
+  @Column
+  private String channelIntroduction;
+
 
   public void setEmailVerified(boolean emailVerified, String emailVerificationToken) {
     isEmailVerified = emailVerified;
@@ -74,4 +83,7 @@ public class User extends BaseTimeEntity {
     this.tokenExpiryAt = tokenExpiryAt;
   }
 
+  public void setRefreshToken(String refreshToken) {
+    this.refreshToken = refreshToken;
+  }
 }


### PR DESCRIPTION
직접 실패했을 때 endoint를 클래스를 만들어서 설정했다.

그다음 refreshToken 관련해서 변경하였다.


![image](https://github.com/se-mi-col-on/Viewtist_BE/assets/143856509/cf62966c-60f3-48b8-8006-184917e85427)


1. 만료된 `accessToken`으로 요청
2. 401 에러
3. `refreshToken`은 Body에 `accessToken`은 헤더에서 받아
4. 헤더에서 받은 `accessToken`의 유저정보와 바디에서 받은 `refreshToken`의 유저정보가 같은지 체크한다
5. 같으면 그 유저정보에서 가져온 `refreshToken`으로 유효성 체크후 
6. new accessToken을 발급한다.

---

스웨거에서 프로필사진 변경을 할 수 있게 수정, 헤더에 jwt토큰을 넣을 수 있게 수정했다.

---

### ❓ 리뷰 포인트

<!-- ex) service 로직 너무 뚱뚱해요 -->

---

### 🦄 관련 이슈

<!-- ex) 테스트 어떤가요. -->

---
