### PR TITLE
[refactor] refreshToken 수정

### DIFF
--- a/common/src/main/java/semicolon/viewtist/CommonApplication.java
+++ b/common/src/main/java/semicolon/viewtist/CommonApplication.java
@@ -10,6 +10,8 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.cloud.openfeign.FeignAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 
 @EnableFeignClients(basePackages = "semicolon.viewtist.mailgun")
@@ -21,6 +23,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @ImportAutoConfiguration({FeignAutoConfiguration.class, HttpClientConfiguration.class})
 @ServletComponentScan
 @EnableJpaAuditing
+@EnableScheduling
+@EnableAsync
 public class CommonApplication {
 
   public static void main(String[] args) {

--- a/common/src/main/java/semicolon/viewtist/CommonApplication.java
+++ b/common/src/main/java/semicolon/viewtist/CommonApplication.java
@@ -14,10 +14,9 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @EnableFeignClients(basePackages = "semicolon.viewtist.mailgun")
 @EnableJpaRepositories(basePackages = {"semicolon.viewtist.user.repository",
-    "semicolon.viewtist.jwt.repository", "semicolon.viewtist.image.repository",
-    "semicolon.viewtist.jwt.repository"})
+    "semicolon.viewtist.jwt.repository", "semicolon.viewtist.image.repository"})
 @EntityScan(basePackages = {"semicolon.viewtist.user.entity", "semicolon.viewtist.jwt.entity",
-    "semicolon.viewtist.image.entity", "semicolon.viewtist.jwt.entity"})
+    "semicolon.viewtist.image.entity"})
 @SpringBootApplication
 @ImportAutoConfiguration({FeignAutoConfiguration.class, HttpClientConfiguration.class})
 @ServletComponentScan

--- a/common/src/main/java/semicolon/viewtist/oauth/OAuth2UserServiceImplement.java
+++ b/common/src/main/java/semicolon/viewtist/oauth/OAuth2UserServiceImplement.java
@@ -2,6 +2,7 @@ package semicolon.viewtist.oauth;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -39,17 +40,22 @@ public class OAuth2UserServiceImplement extends DefaultOAuth2UserService {
     SocialUserRequest socialUserRequest;
     if (oauthClientName.equals("kakao")) {
       userId = "kakao_" + oAuth2User.getAttributes().get("id");
-      @SuppressWarnings("unchecked")
-      Map<String, String> properties = (Map<String, String>) oAuth2User.getAttributes()
-          .get("properties");
-      photoUrl = properties.get("profile_image");
-      socialUserRequest = SocialUserRequest.builder()
-          .userId(userId)
-          .type(Type.kakao)
-          .profilePhotoUrl(photoUrl)
-          .email(userId + "@email.com")
-          .build();
-      user = SocialUserRequest.from(socialUserRequest);
+      Optional<User> optionalUser = userRepository.findByNickname(userId);
+      if (optionalUser.isPresent()) {
+        return new CustomOAuth2User(userId);
+      } else {
+        @SuppressWarnings("unchecked")
+        Map<String, String> properties = (Map<String, String>) oAuth2User.getAttributes()
+            .get("properties");
+        photoUrl = properties.get("profile_image");
+        socialUserRequest = SocialUserRequest.builder()
+            .userId(userId)
+            .type(Type.kakao)
+            .profilePhotoUrl(photoUrl)
+            .email(userId + "@email.com")
+            .build();
+        user = SocialUserRequest.from(socialUserRequest);
+      }
     }
 
     if (oauthClientName.equals("naver")) {
@@ -57,30 +63,40 @@ public class OAuth2UserServiceImplement extends DefaultOAuth2UserService {
       Map<String, String> response = (Map<String, String>) oAuth2User.getAttributes()
           .get("response");
       userId = "naver_" + response.get("id").substring(0, 14);
-      email = response.get("email");
-      photoUrl = response.get("profile_image");
-      socialUserRequest = SocialUserRequest.builder()
-          .userId(userId)
-          .type(Type.naver)
-          .profilePhotoUrl(photoUrl)
-          .email(email)
-          .build();
-      user = SocialUserRequest.from(socialUserRequest);
+      Optional<User> optionalUser = userRepository.findByNickname(userId);
+      if (optionalUser.isPresent()) {
+        return new CustomOAuth2User(userId);
+      } else {
+        email = response.get("email");
+        photoUrl = response.get("profile_image");
+        socialUserRequest = SocialUserRequest.builder()
+            .userId(userId)
+            .type(Type.naver)
+            .profilePhotoUrl(photoUrl)
+            .email(email)
+            .build();
+        user = SocialUserRequest.from(socialUserRequest);
+      }
     }
 
     if (oauthClientName.equals("Google")) {
       userId = "google_" + oAuth2User.getAttributes().get("sub");
-      email = oAuth2User.getAttributes().get("email").toString();
-      photoUrl = oAuth2User.getAttributes().get("picture").toString();
+      Optional<User> optionalUser = userRepository.findByNickname(userId);
+      if (optionalUser.isPresent()) {
+        return new CustomOAuth2User(userId);
+      } else {
+        email = oAuth2User.getAttributes().get("email").toString();
+        photoUrl = oAuth2User.getAttributes().get("picture").toString();
 
-      socialUserRequest = SocialUserRequest.builder()
-          .userId(userId)
-          .type(Type.google)
-          .profilePhotoUrl(photoUrl)
-          .email(email)
-          .build();
+        socialUserRequest = SocialUserRequest.builder()
+            .userId(userId)
+            .type(Type.google)
+            .profilePhotoUrl(photoUrl)
+            .email(email)
+            .build();
 
-      user = SocialUserRequest.from(socialUserRequest);
+        user = SocialUserRequest.from(socialUserRequest);
+      }
     }
     userRepository.save(Objects.requireNonNull(user));
     return new CustomOAuth2User(userId);

--- a/common/src/main/java/semicolon/viewtist/oauth/handler/OAuth2SuccessHandler.java
+++ b/common/src/main/java/semicolon/viewtist/oauth/handler/OAuth2SuccessHandler.java
@@ -12,6 +12,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 import semicolon.viewtist.jwt.TokenProvider;
+import semicolon.viewtist.jwt.entity.RefreshToken;
+import semicolon.viewtist.jwt.repository.RefreshTokenRepository;
 import semicolon.viewtist.oauth.CustomOAuth2User;
 import semicolon.viewtist.user.entity.User;
 import semicolon.viewtist.user.exception.UserException;
@@ -21,6 +23,7 @@ import semicolon.viewtist.user.repository.UserRepository;
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
+  private final RefreshTokenRepository refreshTokenRepository;
   private final UserRepository userRepository;
   private final TokenProvider tokenProvider;
 
@@ -33,10 +36,10 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         .orElseThrow(() -> new UserException(USER_NOT_FOUND));
 
     String accessToken = tokenProvider.generateToken(user);
-    String refreshToken = tokenProvider.generateRefreshToken(user);
+    String refreshToken = tokenProvider.generateRefreshToken(accessToken);
 
-    user.setRefreshToken(refreshToken);
-    userRepository.save(user);
+    RefreshToken newRefreshToken = RefreshToken.builder().refreshToken(refreshToken).build();
+    refreshTokenRepository.save(newRefreshToken);
 
     response.setContentType("application/json");
     response.setCharacterEncoding("UTF-8");

--- a/common/src/main/java/semicolon/viewtist/user/controller/UserController.java
+++ b/common/src/main/java/semicolon/viewtist/user/controller/UserController.java
@@ -2,7 +2,6 @@ package semicolon.viewtist.user.controller;
 
 import io.swagger.v3.oas.annotations.Parameter;
 import java.io.IOException;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -17,7 +16,6 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import semicolon.viewtist.s3.S3UploaderService;
-import semicolon.viewtist.user.dto.request.UpdateMypage;
 import semicolon.viewtist.user.dto.request.UpdatePasswordRequest;
 import semicolon.viewtist.user.dto.response.UserResponse;
 import semicolon.viewtist.user.service.UserService;
@@ -63,38 +61,45 @@ public class UserController {
 //  }
 
   @PreAuthorize("isAuthenticated()")
-  @PutMapping(value ="/update-profile-photo",
+  @PutMapping(value = "/update-profile-photo",
       consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<String> updateProfilePhoto(@Parameter(
       description = "multipart/form-data 형식의 이미지 리스트를 input으로 받습니다. 이때 key 값은 multipartFile 입니다."
   )
-      @RequestPart("file") MultipartFile file,
+  @RequestPart("file") MultipartFile file,
       Authentication authentication) throws IOException {
     String photoUrl = userService.updateProfilePhoto(file, authentication);
     return ResponseEntity.ok(photoUrl);
   }
 
   @PreAuthorize("isAuthenticated()")
-  @PutMapping("/update-mypage")
-  public ResponseEntity<String> updateMypage(@RequestBody UpdateMypage updateMypage,
+  @PutMapping("/update-nickname")
+  public ResponseEntity<String> updateMypage(@RequestBody String updateNickname,
       Authentication authentication) {
-    userService.updateUserProfile(updateMypage.getNickname(),
-        updateMypage.getChannelIntroduction(), authentication);
-    return ResponseEntity.ok("채널관리가 수정되었습니다.");
+    userService.updateNickname(updateNickname, authentication);
+    return ResponseEntity.ok("닉네임이 수정되었습니다.");
+  }
+
+  @PreAuthorize("isAuthenticated()")
+  @PutMapping("/update-introduction")
+  public ResponseEntity<String> updateIntroduction(@RequestBody String updateIntroduction,
+      Authentication authentication) {
+    userService.updateIntroduction(updateIntroduction, authentication);
+    return ResponseEntity.ok("소개글이 수정되었습니다.");
   }
 
   @PreAuthorize("isAuthenticated()")
   @GetMapping("/stream-key")
-  public ResponseEntity<Map<String, String>> getStreamKey(Authentication authentication) {
+  public ResponseEntity<String> getStreamKey(Authentication authentication) {
     String streamKey = userService.getStreamKey(authentication);
-    return ResponseEntity.ok(Map.of("streamKey", streamKey));
+    return ResponseEntity.ok(streamKey);
   }
 
   @PreAuthorize("isAuthenticated()")
   @GetMapping("/refresh-stream-key")
-  public ResponseEntity<Map<String, String>> refreshStreamKey(Authentication authentication) {
+  public ResponseEntity<String> refreshStreamKey(Authentication authentication) {
     String newStreamKey = userService.refreshStreamKey(authentication);
-    return ResponseEntity.ok(Map.of("streamKey", newStreamKey));
+    return ResponseEntity.ok(newStreamKey);
   }
 }
 

--- a/common/src/main/java/semicolon/viewtist/user/controller/UserController.java
+++ b/common/src/main/java/semicolon/viewtist/user/controller/UserController.java
@@ -16,6 +16,8 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import semicolon.viewtist.s3.S3UploaderService;
+import semicolon.viewtist.user.dto.request.UpdateIntroduction;
+import semicolon.viewtist.user.dto.request.UpdateNickname;
 import semicolon.viewtist.user.dto.request.UpdatePasswordRequest;
 import semicolon.viewtist.user.dto.response.UserResponse;
 import semicolon.viewtist.user.service.UserService;
@@ -74,7 +76,7 @@ public class UserController {
 
   @PreAuthorize("isAuthenticated()")
   @PutMapping("/update-nickname")
-  public ResponseEntity<String> updateMypage(@RequestBody String updateNickname,
+  public ResponseEntity<String> updateMypage(@RequestBody UpdateNickname updateNickname,
       Authentication authentication) {
     userService.updateNickname(updateNickname, authentication);
     return ResponseEntity.ok("닉네임이 수정되었습니다.");
@@ -82,7 +84,7 @@ public class UserController {
 
   @PreAuthorize("isAuthenticated()")
   @PutMapping("/update-introduction")
-  public ResponseEntity<String> updateIntroduction(@RequestBody String updateIntroduction,
+  public ResponseEntity<String> updateIntroduction(@RequestBody UpdateIntroduction updateIntroduction,
       Authentication authentication) {
     userService.updateIntroduction(updateIntroduction, authentication);
     return ResponseEntity.ok("소개글이 수정되었습니다.");

--- a/common/src/main/java/semicolon/viewtist/user/controller/UserController.java
+++ b/common/src/main/java/semicolon/viewtist/user/controller/UserController.java
@@ -63,8 +63,7 @@ public class UserController {
 //  }
 
   @PreAuthorize("isAuthenticated()")
-  @PutMapping(value = "/update-profile-photo",
-      consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+  @PutMapping(value = "/update-profile-photo", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
   public ResponseEntity<String> updateProfilePhoto(@Parameter(
       description = "multipart/form-data 형식의 이미지 리스트를 input으로 받습니다. 이때 key 값은 multipartFile 입니다."
   )

--- a/common/src/main/java/semicolon/viewtist/user/service/AuthService.java
+++ b/common/src/main/java/semicolon/viewtist/user/service/AuthService.java
@@ -138,13 +138,12 @@ public class AuthService {
   public String refreshToken(String accessToken, String refreshToken) {
     String accessTokenEmail = extractEmailFromToken(accessToken);
 
-    String email = tokenProvider.getUserIdFromToken(refreshToken);
+    String nickname = tokenProvider.getUserIdFromToken(refreshToken);
+    User refreshUser = findUserByNickname(nickname);
 
-    if (!email.equals(accessTokenEmail)) {
+    if (!refreshUser.getEmail().equals(accessTokenEmail)) {
       throw new UserException(INVALID_TOKEN);
     }
-
-    User refreshUser = findUserByEmail(email);
 
     validateRefreshToken(refreshUser);
 
@@ -153,6 +152,11 @@ public class AuthService {
 
   private User findUserByEmail(String email) {
     return userRepository.findByEmail(email)
+        .orElseThrow(() -> new UserException(USER_NOT_FOUND));
+  }
+
+  private User findUserByNickname(String nickname) {
+    return userRepository.findByNickname(nickname)
         .orElseThrow(() -> new UserException(USER_NOT_FOUND));
   }
 

--- a/common/src/main/java/semicolon/viewtist/user/service/AuthService.java
+++ b/common/src/main/java/semicolon/viewtist/user/service/AuthService.java
@@ -147,11 +147,14 @@ public class AuthService {
 
     String oldAccessToken = tokenProvider.getAccessTokenFromToken(refreshToken);
 
-    if (!accessToken.substring(7).equals(oldAccessToken)) {
+    String oldAccessTokenEmail = tokenProvider.getAccessTokenFromToken(oldAccessToken);
+
+    if (!accessTokenEmail.equals(oldAccessTokenEmail)) {
       throw new UserException(INVALID_TOKEN);
     }
 
     validateRefreshToken(refreshToken);
+
 
     return tokenProvider.generateToken(user);
   }

--- a/common/src/main/java/semicolon/viewtist/user/service/SchedulerService.java
+++ b/common/src/main/java/semicolon/viewtist/user/service/SchedulerService.java
@@ -1,0 +1,26 @@
+package semicolon.viewtist.user.service;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import semicolon.viewtist.jwt.repository.RefreshTokenRepository;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SchedulerService {
+
+  private final RefreshTokenRepository refreshTokenRepository;
+
+  @Transactional
+  @Async
+  @Scheduled(cron = "0 0 0 * * *")
+  public void autoDelete() {
+    log.info("24시간이 지난 refresh token이 삭제되었습니다.");
+    refreshTokenRepository.deleteByCreatedAtLessThanEqual(LocalDateTime.now().minusDays(1));
+  }
+}

--- a/common/src/main/java/semicolon/viewtist/user/service/UserService.java
+++ b/common/src/main/java/semicolon/viewtist/user/service/UserService.java
@@ -19,6 +19,8 @@ import semicolon.viewtist.image.repository.ImageRepository;
 import semicolon.viewtist.mailgun.MailgunClient;
 import semicolon.viewtist.mailgun.SendMailForm;
 import semicolon.viewtist.s3.S3UploaderService;
+import semicolon.viewtist.user.dto.request.UpdateIntroduction;
+import semicolon.viewtist.user.dto.request.UpdateNickname;
 import semicolon.viewtist.user.dto.request.UpdatePasswordRequest;
 import semicolon.viewtist.user.dto.response.UserResponse;
 import semicolon.viewtist.user.entity.User;
@@ -125,27 +127,27 @@ public class UserService {
 
   // 유저 닉네임 수정
   @Transactional
-  public void updateNickname(String updateNickname,
+  public void updateNickname(UpdateNickname updateNickname,
       Authentication authentication) {
     User user = findByEmailOrThrow(authentication.getName());
 
     // 닉네임 중복 확인
-    if (userRepository.existsByNickname(updateNickname)) {
+    if (userRepository.existsByNickname(updateNickname.getNickname())) {
       throw new UserException(ALREADY_EXISTS_NICKNAME);
     }
 
     // 닉네임과 업데이트
-    user.setNickname(updateNickname);
+    user.setNickname(updateNickname.getNickname());
 
     userRepository.save(user);
   }
 
   // 유저 소개글 수정
   @Transactional
-  public void updateIntroduction(String updateIntroduction, Authentication authentication) {
+  public void updateIntroduction(UpdateIntroduction updateIntroduction, Authentication authentication) {
     User user = findByEmailOrThrow(authentication.getName());
 
-    user.setChannelIntroduction(updateIntroduction);
+    user.setChannelIntroduction(updateIntroduction.getIntroduction());
 
     userRepository.save(user);
   }

--- a/common/src/main/java/semicolon/viewtist/user/service/UserService.java
+++ b/common/src/main/java/semicolon/viewtist/user/service/UserService.java
@@ -125,17 +125,27 @@ public class UserService {
 
   // 유저 닉네임 수정
   @Transactional
-  public void updateUserProfile(String nickname, String introduction,
+  public void updateNickname(String updateNickname,
       Authentication authentication) {
     User user = findByEmailOrThrow(authentication.getName());
 
     // 닉네임 중복 확인
-    if (userRepository.existsByNickname(nickname)) {
+    if (userRepository.existsByNickname(updateNickname)) {
       throw new UserException(ALREADY_EXISTS_NICKNAME);
     }
 
-    // 닉네임과 소개글 업데이트
-    user.setUpdateUserProfile(nickname, introduction);
+    // 닉네임과 업데이트
+    user.setNickname(updateNickname);
+
+    userRepository.save(user);
+  }
+
+  // 유저 소개글 수정
+  @Transactional
+  public void updateIntroduction(String updateIntroduction, Authentication authentication) {
+    User user = findByEmailOrThrow(authentication.getName());
+
+    user.setChannelIntroduction(updateIntroduction);
 
     userRepository.save(user);
   }

--- a/domain/src/main/java/semicolon/viewtist/jwt/TokenProvider.java
+++ b/domain/src/main/java/semicolon/viewtist/jwt/TokenProvider.java
@@ -25,7 +25,7 @@ import semicolon.viewtist.user.exception.UserException;
 @Component
 public class TokenProvider {
 
-  private static final long TOKEN_EXPIRE_TIME = 1000 * 60; // 1분
+  private static final long TOKEN_EXPIRE_TIME = 1000 * 60 * 60; // 1시간
   private static final long REFRESH_TOKEN_EXPIRE_TIME = TOKEN_EXPIRE_TIME * 24; // 24시간
 
   @Value("${spring.jwt.key}")

--- a/domain/src/main/java/semicolon/viewtist/jwt/TokenProvider.java
+++ b/domain/src/main/java/semicolon/viewtist/jwt/TokenProvider.java
@@ -84,12 +84,12 @@ public class TokenProvider {
   }
 
   // 리프레시 토큰 생성
-  public String generateRefreshToken(User user) {
+  public String generateRefreshToken(String accessToken) {
     Date now = new Date();
     Date expiredDate = new Date(now.getTime() + REFRESH_TOKEN_EXPIRE_TIME);
 
     return Jwts.builder()
-        .setSubject(user.getNickname())
+        .setSubject(accessToken)
         .setIssuedAt(now)
         .setExpiration(expiredDate)
         .signWith(secretKey, SignatureAlgorithm.HS256)
@@ -97,7 +97,7 @@ public class TokenProvider {
   }
 
   // 토큰에서 유저 아이디 추출(유저 아이디 사용하여 유저 정보 조회)
-  public String getUserIdFromToken(String token) {
+  public String getAccessTokenFromToken(String token) {
     Claims claims = parseClaims(token);
     return claims.getSubject();
   }

--- a/domain/src/main/java/semicolon/viewtist/jwt/TokenProvider.java
+++ b/domain/src/main/java/semicolon/viewtist/jwt/TokenProvider.java
@@ -89,7 +89,7 @@ public class TokenProvider {
     Date expiredDate = new Date(now.getTime() + REFRESH_TOKEN_EXPIRE_TIME);
 
     return Jwts.builder()
-        .setSubject(user.getEmail())
+        .setSubject(user.getNickname())
         .setIssuedAt(now)
         .setExpiration(expiredDate)
         .signWith(secretKey, SignatureAlgorithm.HS256)

--- a/domain/src/main/java/semicolon/viewtist/jwt/entity/RefreshToken.java
+++ b/domain/src/main/java/semicolon/viewtist/jwt/entity/RefreshToken.java
@@ -1,0 +1,27 @@
+package semicolon.viewtist.jwt.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RefreshToken {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(length = 1024)
+  private String refreshToken;
+
+}

--- a/domain/src/main/java/semicolon/viewtist/jwt/entity/RefreshToken.java
+++ b/domain/src/main/java/semicolon/viewtist/jwt/entity/RefreshToken.java
@@ -9,13 +9,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import semicolon.viewtist.global.entitiy.BaseTimeEntity;
 
 @Entity
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class RefreshToken {
+public class RefreshToken extends BaseTimeEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/domain/src/main/java/semicolon/viewtist/jwt/repository/RefreshTokenRepository.java
+++ b/domain/src/main/java/semicolon/viewtist/jwt/repository/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package semicolon.viewtist.jwt.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import semicolon.viewtist.jwt.entity.RefreshToken;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+  boolean existsByRefreshToken(String refreshToken);
+}

--- a/domain/src/main/java/semicolon/viewtist/jwt/repository/RefreshTokenRepository.java
+++ b/domain/src/main/java/semicolon/viewtist/jwt/repository/RefreshTokenRepository.java
@@ -1,5 +1,6 @@
 package semicolon.viewtist.jwt.repository;
 
+import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import semicolon.viewtist.jwt.entity.RefreshToken;
@@ -8,4 +9,6 @@ import semicolon.viewtist.jwt.entity.RefreshToken;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
   boolean existsByRefreshToken(String refreshToken);
+
+  void deleteByCreatedAtLessThanEqual(LocalDateTime localDateTime);
 }

--- a/domain/src/main/java/semicolon/viewtist/jwt/repository/TokenBlacklistRepository.java
+++ b/domain/src/main/java/semicolon/viewtist/jwt/repository/TokenBlacklistRepository.java
@@ -1,8 +1,10 @@
 package semicolon.viewtist.jwt.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 import semicolon.viewtist.jwt.entity.TokenBlacklist;
 
+@Repository
 public interface TokenBlacklistRepository extends JpaRepository<TokenBlacklist, Long> {
 
   boolean existsByToken(String token);

--- a/domain/src/main/java/semicolon/viewtist/user/dto/request/UpdateIntroduction.java
+++ b/domain/src/main/java/semicolon/viewtist/user/dto/request/UpdateIntroduction.java
@@ -1,0 +1,18 @@
+package semicolon.viewtist.user.dto.request;
+
+import javax.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UpdateIntroduction {
+
+  @NotBlank(message = "소개글을 입력해 주세요.")
+  private String Introduction;
+
+}

--- a/domain/src/main/java/semicolon/viewtist/user/dto/request/UpdateNickname.java
+++ b/domain/src/main/java/semicolon/viewtist/user/dto/request/UpdateNickname.java
@@ -10,12 +10,9 @@ import lombok.Setter;
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
-public class UpdateMypage {
+public class UpdateNickname {
 
   @NotBlank(message = "닉네임을 입력해 주세요.")
   private String nickname;
-
-  @NotBlank(message = "채널 소개를 적어주세요")
-  private String channelIntroduction;
 
 }

--- a/domain/src/main/java/semicolon/viewtist/user/entity/User.java
+++ b/domain/src/main/java/semicolon/viewtist/user/entity/User.java
@@ -52,9 +52,6 @@ public class User extends BaseTimeEntity {
   private LocalDateTime tokenExpiryAt;
 
   @Column
-  private String refreshToken;
-
-  @Column
   private String streamKey;
 
   @Column
@@ -76,9 +73,6 @@ public class User extends BaseTimeEntity {
     this.tokenExpiryAt = tokenExpiryAt;
   }
 
-  public void setRefreshToken(String refreshToken) {
-    this.refreshToken = refreshToken;
-  }
 
   public void setStreamKey(String streamKey) {
     this.streamKey = streamKey;

--- a/domain/src/main/java/semicolon/viewtist/user/entity/User.java
+++ b/domain/src/main/java/semicolon/viewtist/user/entity/User.java
@@ -84,12 +84,15 @@ public class User extends BaseTimeEntity {
     this.profilePhotoUrl = profilePhotoUrl;
   }
 
-  public void setUpdateUserProfile(String nickname, String introduction) {
-    this.nickname = nickname;
-    this.channelIntroduction = introduction;
-  }
-
   public void setPassword(String password) {
     this.password = password;
+  }
+
+  public void setNickname(String nickname) {
+    this.nickname = nickname;
+  }
+
+  public void setChannelIntroduction(String updateIntroduction) {
+    this.channelIntroduction = updateIntroduction;
   }
 }


### PR DESCRIPTION
<!-- 제목은 ex) `[컨벤션] 제목` 으로 작성한다. ex) [feature] 결제 기능 -->

---

### 🌱 작업 사항

`refreshToken` 식별자를 `accessToken`으로 변경 `accessToken` 만 발급할 수 있는 용도로 변경

`refreshToken` 토큰이 `refresh 테이블`에 토큰에 있고, `refreshToken `안에 있는 `accessToken` 안에 있는 유저정보와 헤더로 받은 `accessToken `의 유저 정보가 일치하면 새로운` accessToken `발급


소셜로그인 로그인 할때마다 데이터베이스에 추가되는 문제 해결

스케줄러 설정으로 24시간 지난 리프레시 토큰을 삭제할 수 있게 구현


닉네임 수정과 소개글 수정을 따로따로 설정할 수 있도록 변경


---

### ❓ 리뷰 포인트

<!-- ex) service 로직 너무 뚱뚱해요 -->

---

### 🦄 관련 이슈

<!-- ex) 테스트 어떤가요. -->

---
