### PR TITLE
[#53]  구독과 알림기능

### DIFF
--- a/chatting-api/build.gradle
+++ b/chatting-api/build.gradle
@@ -12,6 +12,8 @@ dependencies {
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2")
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
     testImplementation 'com.h2database:h2'
 }
 

--- a/chatting-api/src/main/java/semicolon/viewtist/ChattingApplication.java
+++ b/chatting-api/src/main/java/semicolon/viewtist/ChattingApplication.java
@@ -16,9 +16,9 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @EnableJpaAuditing
 @EnableJpaRepositories(basePackages = {"semicolon.viewtist.chatting.repository",
-    "semicolon.viewtist.jwt.repository", "semicolon.viewtist.user.repository"})
+    "semicolon.viewtist.jwt.repository", "semicolon.viewtist.user.repository", "semicolon.viewtist.sse.repository"})
 @EntityScan(basePackages = {"semicolon.viewtist.chatting.entity",
-    "semicolon.viewtist.jwt.entity", "semicolon.viewtist.user.entity"})
+    "semicolon.viewtist.jwt.entity", "semicolon.viewtist.user.entity", "semicolon.viewtist.sse.entity"})
 @SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 public class ChattingApplication {
 

--- a/common/src/main/java/semicolon/viewtist/CommonApplication.java
+++ b/common/src/main/java/semicolon/viewtist/CommonApplication.java
@@ -16,9 +16,9 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableFeignClients(basePackages = "semicolon.viewtist.mailgun")
 @EnableJpaRepositories(basePackages = {"semicolon.viewtist.user.repository",
-    "semicolon.viewtist.jwt.repository", "semicolon.viewtist.image.repository"})
+    "semicolon.viewtist.jwt.repository", "semicolon.viewtist.image.repository", "semicolon.viewtist.sse.repository"})
 @EntityScan(basePackages = {"semicolon.viewtist.user.entity", "semicolon.viewtist.jwt.entity",
-    "semicolon.viewtist.image.entity"})
+    "semicolon.viewtist.image.entity","semicolon.viewtist.sse.entity"})
 @SpringBootApplication
 @ImportAutoConfiguration({FeignAutoConfiguration.class, HttpClientConfiguration.class})
 @ServletComponentScan

--- a/common/src/main/java/semicolon/viewtist/user/controller/SubscribeController.java
+++ b/common/src/main/java/semicolon/viewtist/user/controller/SubscribeController.java
@@ -1,14 +1,18 @@
 package semicolon.viewtist.user.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import semicolon.viewtist.user.dto.response.SubscribeResponse;
 import semicolon.viewtist.user.service.SubscribeService;
 
 @RestController
@@ -33,6 +37,12 @@ public class SubscribeController {
       Authentication authentication) {
     subscribeService.unsubscribe(streamerNickname, authentication);
     return ResponseEntity.ok("구독이 취소되었습니다.");
+  }
+
+  @PreAuthorize("isAuthenticated()")
+  @GetMapping("/subscribe")
+  public Page<SubscribeResponse> getSubscribeList(Authentication authentication, Pageable pageable) {
+    return subscribeService.getSubscribeList(authentication,pageable);
   }
 
 

--- a/common/src/main/java/semicolon/viewtist/user/controller/SubscribeController.java
+++ b/common/src/main/java/semicolon/viewtist/user/controller/SubscribeController.java
@@ -1,0 +1,39 @@
+package semicolon.viewtist.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import semicolon.viewtist.user.service.SubscribeService;
+
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class SubscribeController {
+
+  private final SubscribeService subscribeService;
+
+  @PreAuthorize("isAuthenticated()")
+  @PostMapping("/subscribe")
+  public ResponseEntity<String> subscribe(@RequestBody String streamerNickname,
+      Authentication authentication) {
+    subscribeService.subscribe(streamerNickname, authentication);
+    return ResponseEntity.ok("구독이 완료되었습니다.");
+  }
+
+
+  @PreAuthorize("isAuthenticated()")
+  @DeleteMapping("/unsubscribe")
+  public ResponseEntity<String> unsubscribe(@RequestBody String streamerNickname,
+      Authentication authentication) {
+    subscribeService.unsubscribe(streamerNickname, authentication);
+    return ResponseEntity.ok("구독이 취소되었습니다.");
+  }
+
+
+}

--- a/common/src/main/java/semicolon/viewtist/user/controller/UserController.java
+++ b/common/src/main/java/semicolon/viewtist/user/controller/UserController.java
@@ -89,7 +89,8 @@ public class UserController {
 
   @PreAuthorize("isAuthenticated()")
   @PutMapping("/introduction")
-  public ResponseEntity<String> updateIntroduction(@RequestBody UpdateIntroduction updateIntroduction,
+  public ResponseEntity<String> updateIntroduction(
+      @RequestBody UpdateIntroduction updateIntroduction,
       Authentication authentication) {
     userService.updateIntroduction(updateIntroduction, authentication);
     return ResponseEntity.ok("소개글이 수정되었습니다.");

--- a/common/src/main/java/semicolon/viewtist/user/service/SubscribeService.java
+++ b/common/src/main/java/semicolon/viewtist/user/service/SubscribeService.java
@@ -1,0 +1,62 @@
+package semicolon.viewtist.user.service;
+
+import static semicolon.viewtist.global.exception.ErrorCode.ALREADY_EXISTS_SUBSCRIBE;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import semicolon.viewtist.global.exception.ErrorCode;
+import semicolon.viewtist.sse.entity.Subscribe;
+import semicolon.viewtist.sse.repository.SubscribeRepository;
+import semicolon.viewtist.user.entity.User;
+import semicolon.viewtist.user.exception.SubscribeException;
+import semicolon.viewtist.user.exception.UserException;
+import semicolon.viewtist.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class SubscribeService {
+
+  private final SubscribeRepository subscribeRepository;
+  private final UserRepository userRepository;
+
+
+  public void subscribe(String streamerNickname, Authentication authentication) {
+
+    User streamer = getUserByNickname(streamerNickname);
+
+    User user = getUserByEmail(authentication.getName());
+
+    if (subscribeRepository.existsByReceiverAndUser(streamerNickname, user.getNickname())) {
+      throw new SubscribeException(ALREADY_EXISTS_SUBSCRIBE);
+    }
+
+    Subscribe subscribe = Subscribe.builder()
+        .user(user.getNickname())
+        .receiver(streamer.getNickname())
+        .build();
+
+    subscribeRepository.save(subscribe);
+  }
+
+
+  public void unsubscribe(String streamerNickname, Authentication authentication) {
+
+    User streamer = getUserByNickname(streamerNickname);
+
+    User user = getUserByEmail(authentication.getName());
+
+    subscribeRepository.deleteByReceiverAndUser(streamer.getNickname(), user.getNickname());
+  }
+
+
+  private User getUserByEmail(String email) {
+    return userRepository.findByEmail(email)
+        .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+  }
+
+  private User getUserByNickname(String nickname) {
+    return userRepository.findByNickname(nickname)
+        .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+  }
+}

--- a/common/src/main/java/semicolon/viewtist/user/service/SubscribeService.java
+++ b/common/src/main/java/semicolon/viewtist/user/service/SubscribeService.java
@@ -3,11 +3,14 @@ package semicolon.viewtist.user.service;
 import static semicolon.viewtist.global.exception.ErrorCode.ALREADY_EXISTS_SUBSCRIBE;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import semicolon.viewtist.global.exception.ErrorCode;
 import semicolon.viewtist.sse.entity.Subscribe;
 import semicolon.viewtist.sse.repository.SubscribeRepository;
+import semicolon.viewtist.user.dto.response.SubscribeResponse;
 import semicolon.viewtist.user.entity.User;
 import semicolon.viewtist.user.exception.SubscribeException;
 import semicolon.viewtist.user.exception.UserException;
@@ -49,6 +52,12 @@ public class SubscribeService {
     subscribeRepository.deleteByReceiverAndUser(streamer.getNickname(), user.getNickname());
   }
 
+  public Page<SubscribeResponse> getSubscribeList(Authentication authentication,
+      Pageable pageable) {
+    User user = getUserByEmail(authentication.getName());
+    Page<Subscribe> subscribe = subscribeRepository.findAllByUser(user.getNickname(), pageable);
+    return subscribe.map(SubscribeResponse::from);
+  }
 
   private User getUserByEmail(String email) {
     return userRepository.findByEmail(email)

--- a/common/src/main/java/semicolon/viewtist/user/service/UserService.java
+++ b/common/src/main/java/semicolon/viewtist/user/service/UserService.java
@@ -155,7 +155,8 @@ public class UserService {
 
   // 유저 소개글 수정
   @Transactional
-  public void updateIntroduction(UpdateIntroduction updateIntroduction, Authentication authentication) {
+  public void updateIntroduction(UpdateIntroduction updateIntroduction,
+      Authentication authentication) {
     User user = findByEmail(authentication.getName());
 
     user.setChannelIntroduction(updateIntroduction.getIntroduction());

--- a/domain/src/main/java/semicolon/viewtist/global/exception/ErrorCode.java
+++ b/domain/src/main/java/semicolon/viewtist/global/exception/ErrorCode.java
@@ -24,6 +24,9 @@ public enum ErrorCode {
   INVALID_TOKEN(UNAUTHORIZED, "유효하지 않은 토큰입니다."),
   TIME_OUT_INVALID_TOKEN(BAD_REQUEST, "인증시간이 만료되었습니다."),
   NOT_VERIFIED_EMAIL(BAD_REQUEST, "이메일 인증을 진행해 주세요."),
+  USER_NOT_MATCH(BAD_REQUEST, "유저정보가 맞지 않습니다."),
+
+  ALREADY_EXISTS_SUBSCRIBE(BAD_REQUEST, "이미 구독되어있습니다."),
 
   SECURITY_UNAUTHORIZED(FORBIDDEN, "승인 실패"),
   ACCESS_DENIED(UNAUTHORIZED, "접근 실패"),

--- a/domain/src/main/java/semicolon/viewtist/global/exception/ErrorCode.java
+++ b/domain/src/main/java/semicolon/viewtist/global/exception/ErrorCode.java
@@ -44,7 +44,7 @@ public enum ErrorCode {
   NOT_EXIST_STREAMKEY(HttpStatus.BAD_REQUEST, "존재하지 않는 스트리밍 방입니다."),
   NOT_EXIST_DESTINATION(HttpStatus.BAD_REQUEST, "destination이 존재하지 않습니다."),
   NOT_ENTER_ANY_ROOM(HttpStatus.BAD_REQUEST, "아직 채팅방에 들어가지 않았습니다."),
-  ALREADY_ENTER_ANOTHER_ROOM(HttpStatus.BAD_REQUEST,"이미 다른 방에 있습니다.");
+  ALREADY_ENTER_ANOTHER_ROOM(HttpStatus.BAD_REQUEST, "이미 다른 방에 있습니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/domain/src/main/java/semicolon/viewtist/global/exception/GlobalExceptionHandler.java
+++ b/domain/src/main/java/semicolon/viewtist/global/exception/GlobalExceptionHandler.java
@@ -6,11 +6,17 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 import semicolon.viewtist.chatting.exception.ChattingException;
 import semicolon.viewtist.jwt.exception.JwtException;
 import semicolon.viewtist.liveStreaming.exception.LiveStreamingException;
+import semicolon.viewtist.user.exception.SubscribeException;
 import semicolon.viewtist.user.exception.UserException;
 
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+  @ExceptionHandler(SubscribeException.class)
+  public ResponseEntity<?> handlerSubscribeException(SubscribeException e) {
+    return toResponse(e.getErrorCode(), e.getMessage());
+  }
 
   @ExceptionHandler(LiveStreamingException.class)
   public ResponseEntity<?> handlerLiveStreamingException(LiveStreamingException e) {

--- a/domain/src/main/java/semicolon/viewtist/global/exception/GlobalExceptionHandler.java
+++ b/domain/src/main/java/semicolon/viewtist/global/exception/GlobalExceptionHandler.java
@@ -22,10 +22,12 @@ public class GlobalExceptionHandler {
   public ResponseEntity<?> handlerLiveStreamingException(LiveStreamingException e) {
     return toResponse(e.getErrorCode(), e.getMessage());
   }
+
   @ExceptionHandler(ChattingException.class)
   public ResponseEntity<?> handlerChattingException(ChattingException e) {
     return toResponse(e.getErrorCode(), e.getMessage());
   }
+
   @ExceptionHandler(UserException.class)
   public ResponseEntity<?> handlerUserException(UserException e) {
     return toResponse(e.getErrorCode(), e.getMessage());

--- a/domain/src/main/java/semicolon/viewtist/sse/dto/response/NotifyStreamingResponse.java
+++ b/domain/src/main/java/semicolon/viewtist/sse/dto/response/NotifyStreamingResponse.java
@@ -1,0 +1,30 @@
+package semicolon.viewtist.sse.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import semicolon.viewtist.sse.entity.Notify;
+
+@AllArgsConstructor
+@Builder
+@NoArgsConstructor
+@Getter
+@Setter
+public class NotifyStreamingResponse {
+
+  String notifyId;
+  String receiverName;
+  String content;
+  String type;
+  public static NotifyStreamingResponse from(Notify notify) {
+    return NotifyStreamingResponse.builder()
+        .content(notify.getContent())
+        .notifyId(notify.getId().toString())
+        .receiverName(notify.getReceiver().getNickname())
+        .type(notify.getNotificationType().toString())
+        .build();
+
+  }
+}

--- a/domain/src/main/java/semicolon/viewtist/sse/dto/response/NotifyStreamingResponse.java
+++ b/domain/src/main/java/semicolon/viewtist/sse/dto/response/NotifyStreamingResponse.java
@@ -18,6 +18,7 @@ public class NotifyStreamingResponse {
   String receiverName;
   String content;
   String type;
+
   public static NotifyStreamingResponse from(Notify notify) {
     return NotifyStreamingResponse.builder()
         .content(notify.getContent())

--- a/domain/src/main/java/semicolon/viewtist/sse/entity/Notify.java
+++ b/domain/src/main/java/semicolon/viewtist/sse/entity/Notify.java
@@ -1,0 +1,50 @@
+package semicolon.viewtist.sse.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import semicolon.viewtist.global.entitiy.BaseTimeEntity;
+import semicolon.viewtist.user.entity.User;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Notify extends BaseTimeEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "notification_id")
+  private Long id;
+
+  private String content;
+
+  @Column(nullable = false)
+  private Boolean isRead;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private NotificationType notificationType;
+
+  @ManyToOne
+  @JoinColumn(name = "user_id")
+  @OnDelete(action = OnDeleteAction.CASCADE)
+  private User receiver;
+
+
+  public enum NotificationType{
+    STREAMING, VIEWTIST, TEST, RESEND,
+  }
+}

--- a/domain/src/main/java/semicolon/viewtist/sse/entity/Notify.java
+++ b/domain/src/main/java/semicolon/viewtist/sse/entity/Notify.java
@@ -24,6 +24,7 @@ import semicolon.viewtist.user.entity.User;
 @NoArgsConstructor
 @Builder
 public class Notify extends BaseTimeEntity {
+
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "notification_id")
@@ -44,7 +45,7 @@ public class Notify extends BaseTimeEntity {
   private User receiver;
 
 
-  public enum NotificationType{
+  public enum NotificationType {
     STREAMING, VIEWTIST, TEST, RESEND,
   }
 }

--- a/domain/src/main/java/semicolon/viewtist/sse/entity/Subscribe.java
+++ b/domain/src/main/java/semicolon/viewtist/sse/entity/Subscribe.java
@@ -1,0 +1,30 @@
+package semicolon.viewtist.sse.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import semicolon.viewtist.global.entitiy.BaseTimeEntity;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Subscribe extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+
+  private String receiver;
+
+
+  private String user;
+
+}

--- a/domain/src/main/java/semicolon/viewtist/sse/repository/EmitterRepository.java
+++ b/domain/src/main/java/semicolon/viewtist/sse/repository/EmitterRepository.java
@@ -1,0 +1,16 @@
+package semicolon.viewtist.sse.repository;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.Map;
+
+public interface EmitterRepository {
+  SseEmitter save(String emitterId, SseEmitter sseEmitter);
+  void saveEventCache(String emitterId, Object event);
+  Map<String, SseEmitter> findAllEmitterStartWithByMemberId(String memberId);
+  Map<String, Object> findAllEventCacheStartWithByUserEmail(String memberId);
+  void delete(String nickname);
+  void deleteAllEmitterStartWithId(String memberId);
+  void deleteAllEventCacheStartWithId(String memberId);
+
+}

--- a/domain/src/main/java/semicolon/viewtist/sse/repository/EmitterRepositoryImpl.java
+++ b/domain/src/main/java/semicolon/viewtist/sse/repository/EmitterRepositoryImpl.java
@@ -1,0 +1,70 @@
+package semicolon.viewtist.sse.repository;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Repository
+public class EmitterRepositoryImpl implements EmitterRepository{
+  private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+  private final Map<String, Object> eventCache = new ConcurrentHashMap<>();
+
+
+  public Optional<SseEmitter> get (String email) {
+    return Optional.ofNullable(emitters.get(email));
+  }
+  @Override
+  public SseEmitter save(String emitterId, SseEmitter sseEmitter) {
+    emitters.put(emitterId, sseEmitter);
+    return sseEmitter;
+  }
+
+  @Override
+  public void saveEventCache(String eventCacheId, Object event) {
+    eventCache.put(eventCacheId, event);
+  }
+
+  @Override
+  public Map<String, SseEmitter> findAllEmitterStartWithByMemberId(String memberId) {
+    return emitters.entrySet().stream()
+        .filter(entry -> entry.getKey().startsWith(memberId))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  @Override
+  public Map<String, Object> findAllEventCacheStartWithByUserEmail(String memberId) {
+    return eventCache.entrySet().stream()
+        .filter(entry -> entry.getKey().startsWith(memberId))
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  @Override
+  public void delete(String nickname) {
+    emitters.remove(nickname);
+  }
+
+  @Override
+  public void deleteAllEmitterStartWithId(String memberId) {
+    emitters.forEach(
+        (key, emitter) -> {
+          if (key.startsWith(memberId)) {
+            emitters.remove(key);
+          }
+        }
+    );
+  }
+
+  @Override
+  public void deleteAllEventCacheStartWithId(String memberId) {
+    eventCache.forEach(
+        (key, emitter) -> {
+          if (key.startsWith(memberId)) {
+            eventCache.remove(key);
+          }
+        }
+    );
+  }
+}

--- a/domain/src/main/java/semicolon/viewtist/sse/repository/NotifyRepository.java
+++ b/domain/src/main/java/semicolon/viewtist/sse/repository/NotifyRepository.java
@@ -1,0 +1,10 @@
+package semicolon.viewtist.sse.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import semicolon.viewtist.sse.entity.Notify;
+
+@Repository
+public interface NotifyRepository extends JpaRepository<Notify, Long> {
+
+}

--- a/domain/src/main/java/semicolon/viewtist/sse/repository/SubscribeRepository.java
+++ b/domain/src/main/java/semicolon/viewtist/sse/repository/SubscribeRepository.java
@@ -1,6 +1,8 @@
 package semicolon.viewtist.sse.repository;
 
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import semicolon.viewtist.sse.entity.Subscribe;
@@ -8,10 +10,12 @@ import semicolon.viewtist.sse.entity.Subscribe;
 @Repository
 public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
 
-  List<Subscribe> findByReceiver(String nickname);
+  Page<Subscribe> findAllByUser(String nickname, Pageable pageable);
 
   void deleteByReceiverAndUser(String receiverNickname, String userNickname);
 
   boolean existsByReceiverAndUser(String receiver, String user);
+
+  List<Subscribe> findByReceiver(String nickname);
 }
 

--- a/domain/src/main/java/semicolon/viewtist/sse/repository/SubscribeRepository.java
+++ b/domain/src/main/java/semicolon/viewtist/sse/repository/SubscribeRepository.java
@@ -1,0 +1,17 @@
+package semicolon.viewtist.sse.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import semicolon.viewtist.sse.entity.Subscribe;
+
+@Repository
+public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
+
+  List<Subscribe> findByReceiver(String nickname);
+
+  void deleteByReceiverAndUser(String receiverNickname, String userNickname);
+
+  boolean existsByReceiverAndUser(String receiver, String user);
+}
+

--- a/domain/src/main/java/semicolon/viewtist/sse/service/NotifyService.java
+++ b/domain/src/main/java/semicolon/viewtist/sse/service/NotifyService.java
@@ -4,7 +4,6 @@ import static semicolon.viewtist.sse.entity.Notify.NotificationType.STREAMING;
 import static semicolon.viewtist.sse.entity.Notify.NotificationType.TEST;
 import static semicolon.viewtist.sse.entity.Notify.NotificationType.VIEWTIST;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.IOException;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -33,8 +32,7 @@ public class NotifyService {
   private final NotifyRepository notifyRepository;
   private final UserRepository userRepository;
 
-  public SseEmitter subscribe(Authentication authentication, String lastEventId)
-      throws JsonProcessingException {
+  public SseEmitter subscribe(Authentication authentication, String lastEventId) {
     User user = userRepository.findByEmail(authentication.getName())
         .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
 

--- a/domain/src/main/java/semicolon/viewtist/sse/service/NotifyService.java
+++ b/domain/src/main/java/semicolon/viewtist/sse/service/NotifyService.java
@@ -32,7 +32,7 @@ public class NotifyService {
   private final NotifyRepository notifyRepository;
   private final UserRepository userRepository;
 
-  public SseEmitter subscribe(Authentication authentication, String lastEventId) {
+  public SseEmitter connect(Authentication authentication, String lastEventId) {
     User user = userRepository.findByEmail(authentication.getName())
         .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
 
@@ -87,10 +87,10 @@ public class NotifyService {
         String.valueOf(userEmail));
     eventCaches.entrySet().stream()
         .filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
-        .forEach(entry -> {
-          sendNotification(emitter, entry.getKey(), emitterId, entry.getValue(),
-              VIEWTIST.toString());
-        });
+        .forEach(entry ->
+            sendNotification(emitter, entry.getKey(), emitterId, entry.getValue(),
+                VIEWTIST.toString())
+        );
   }
 
   public void streamingNotifySend(String receiver, NotificationType notificationType,

--- a/domain/src/main/java/semicolon/viewtist/sse/service/NotifyService.java
+++ b/domain/src/main/java/semicolon/viewtist/sse/service/NotifyService.java
@@ -1,0 +1,137 @@
+package semicolon.viewtist.sse.service;
+
+import static semicolon.viewtist.sse.entity.Notify.NotificationType.STREAMING;
+import static semicolon.viewtist.sse.entity.Notify.NotificationType.TEST;
+import static semicolon.viewtist.sse.entity.Notify.NotificationType.VIEWTIST;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.IOException;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import semicolon.viewtist.global.exception.ErrorCode;
+import semicolon.viewtist.sse.dto.response.NotifyStreamingResponse;
+import semicolon.viewtist.sse.entity.Notify;
+import semicolon.viewtist.sse.entity.Notify.NotificationType;
+import semicolon.viewtist.sse.repository.EmitterRepositoryImpl;
+import semicolon.viewtist.sse.repository.NotifyRepository;
+import semicolon.viewtist.user.entity.User;
+import semicolon.viewtist.user.exception.UserException;
+import semicolon.viewtist.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NotifyService {
+
+  private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60;
+
+  private final EmitterRepositoryImpl emitterRepository;
+  private final NotifyRepository notifyRepository;
+  private final UserRepository userRepository;
+
+  public SseEmitter subscribe(Authentication authentication, String lastEventId)
+      throws JsonProcessingException {
+    User user = userRepository.findByEmail(authentication.getName())
+        .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+
+    String emitterId = user.getNickname();
+
+    SseEmitter emitter = emitterRepository.save(emitterId, new SseEmitter(DEFAULT_TIMEOUT));
+    emitter.onCompletion(() -> {
+      log.info("Emitter completed. [emitterId={}]", emitterId);
+      emitterRepository.delete(emitterId);
+    });
+    emitter.onTimeout(() -> {
+      log.info("Emitter timeout. [emitterId={}]", emitterId);
+      emitterRepository.delete(emitterId);
+    });
+    // 503 에러를 방지하기 위한 더미 이벤트 전송
+    String eventId = makeTimeIncludeId(authentication.getName());
+    sendNotification(emitter, eventId, emitterId,
+        "EventStream Created. [userEmail=" + authentication.getName() + "]", TEST.toString());
+
+    // 클라이언트가 미수신한 Event 목록이 존재할 경우 전송하여 Event 유실을 예방
+    if (hasLostData(lastEventId)) {
+      sendLostData(lastEventId, authentication.getName(), emitterId, emitter);
+    }
+    return emitter;
+  }
+
+
+  private String makeTimeIncludeId(String email) {
+    return email + "_" + System.currentTimeMillis();
+  }
+
+  private void sendNotification(SseEmitter emitter, String eventId, String emitterId, Object data,
+      String notificationType) {
+    try {
+      emitter.send(SseEmitter.event()
+          .id(eventId)
+          .name(notificationType)
+          .data(data)
+      );
+    } catch (IOException exception) {
+      emitterRepository.delete(emitterId);
+    }
+  }
+
+  private boolean hasLostData(String lastEventId) {
+    return !lastEventId.isEmpty();
+  }
+
+  private void sendLostData(String lastEventId, String userEmail, String emitterId,
+      SseEmitter emitter) {
+    Map<String, Object> eventCaches = emitterRepository.findAllEventCacheStartWithByUserEmail(
+        String.valueOf(userEmail));
+    eventCaches.entrySet().stream()
+        .filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
+        .forEach(entry -> {
+          sendNotification(emitter, entry.getKey(), emitterId, entry.getValue(),
+              VIEWTIST.toString());
+        });
+  }
+
+  public void streamingNotifySend(String receiver, NotificationType notificationType,
+      String content) {
+
+    String eventId = receiver + "_" + System.currentTimeMillis();
+
+    NotifyStreamingResponse response = NotifyStreamingResponse.builder()
+        .receiverName(receiver)
+        .notifyId(eventId)
+        .content(content)
+        .type(STREAMING.toString())
+        .build();
+
+    User receiverUser = userRepository.findByNickname(receiver)
+        .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));
+
+    notifyRepository.save(
+        createNotification(receiverUser, notificationType, response.getContent()));
+
+    emitterRepository.get(receiver).ifPresentOrElse(sseEmitter -> {
+      try {
+        sseEmitter.send(
+            SseEmitter.event().id(eventId).name(String.valueOf(STREAMING))
+                .data(response));
+      } catch (IOException e) {
+        emitterRepository.delete(receiver);
+      }
+    }, () -> log.info("[SseEmitter] {} SseEmitter Not Founded", receiver));
+  }
+
+  private Notify createNotification(User receiver, NotificationType notificationType,
+      String content) {
+    return Notify.builder()
+        .receiver(receiver)
+        .notificationType(notificationType)
+        .content(content)
+        .isRead(false)
+        .build();
+  }
+
+}

--- a/domain/src/main/java/semicolon/viewtist/user/dto/request/UserSignupRequest.java
+++ b/domain/src/main/java/semicolon/viewtist/user/dto/request/UserSignupRequest.java
@@ -26,7 +26,6 @@ public class UserSignupRequest {
   private String password;
 
 
-
   public static UserSignupRequest from(User user) {
     return UserSignupRequest.builder()
         .email(user.getEmail())

--- a/domain/src/main/java/semicolon/viewtist/user/dto/response/SubscribeResponse.java
+++ b/domain/src/main/java/semicolon/viewtist/user/dto/response/SubscribeResponse.java
@@ -1,0 +1,26 @@
+package semicolon.viewtist.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import semicolon.viewtist.sse.entity.Subscribe;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class SubscribeResponse {
+
+  private String streamerNickname;
+
+  private String nickname;
+
+  public static SubscribeResponse from(Subscribe subscribe) {
+    return SubscribeResponse.builder()
+        .streamerNickname(subscribe.getReceiver())
+        .nickname(subscribe.getUser())
+        .build();
+
+  }
+}

--- a/domain/src/main/java/semicolon/viewtist/user/exception/SubscribeException.java
+++ b/domain/src/main/java/semicolon/viewtist/user/exception/SubscribeException.java
@@ -1,0 +1,15 @@
+package semicolon.viewtist.user.exception;
+
+import semicolon.viewtist.global.exception.CustomException;
+import semicolon.viewtist.global.exception.ErrorCode;
+
+public class SubscribeException extends CustomException {
+
+  public SubscribeException(ErrorCode errorCode) {
+    super(errorCode);
+  }
+
+  public SubscribeException(ErrorCode errorCode, String msg) {
+    super(errorCode, msg);
+  }
+}

--- a/streaming-api/src/main/java/semicolon/viewtist/LiveStreamingApplication.java
+++ b/streaming-api/src/main/java/semicolon/viewtist/LiveStreamingApplication.java
@@ -15,9 +15,9 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
     "semicolon.viewtist.user.entity", "semicolon.viewtist.jwt.entity",
     "semicolon.viewtist.sse.entity"})
 @EnableJpaAuditing
-public class StreamingApplication {
+public class LiveStreamingApplication {
 
   public static void main(String[] args) {
-    SpringApplication.run(StreamingApplication.class, args);
+    SpringApplication.run(LiveStreamingApplication.class, args);
   }
 }

--- a/streaming-api/src/main/java/semicolon/viewtist/StreamingApplication.java
+++ b/streaming-api/src/main/java/semicolon/viewtist/StreamingApplication.java
@@ -9,9 +9,11 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
 @EnableJpaRepositories(basePackages = {"semicolon.viewtist.liveStreaming.repository",
-    "semicolon.viewtist.user.repository", "semicolon.viewtist.jwt.repository", "semicolon.viewtist.sse.repository"})
+    "semicolon.viewtist.user.repository", "semicolon.viewtist.jwt.repository",
+    "semicolon.viewtist.sse.repository"})
 @EntityScan(basePackages = {"semicolon.viewtist.liveStreaming.entity",
-    "semicolon.viewtist.user.entity", "semicolon.viewtist.jwt.entity", "semicolon.viewtist.sse.entity"})
+    "semicolon.viewtist.user.entity", "semicolon.viewtist.jwt.entity",
+    "semicolon.viewtist.sse.entity"})
 @EnableJpaAuditing
 public class StreamingApplication {
 

--- a/streaming-api/src/main/java/semicolon/viewtist/StreamingApplication.java
+++ b/streaming-api/src/main/java/semicolon/viewtist/StreamingApplication.java
@@ -9,9 +9,9 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
 @EnableJpaRepositories(basePackages = {"semicolon.viewtist.liveStreaming.repository",
-    "semicolon.viewtist.user.repository", "semicolon.viewtist.jwt.repository"})
+    "semicolon.viewtist.user.repository", "semicolon.viewtist.jwt.repository", "semicolon.viewtist.sse.repository"})
 @EntityScan(basePackages = {"semicolon.viewtist.liveStreaming.entity",
-    "semicolon.viewtist.user.entity", "semicolon.viewtist.jwt.entity"})
+    "semicolon.viewtist.user.entity", "semicolon.viewtist.jwt.entity", "semicolon.viewtist.sse.entity"})
 @EnableJpaAuditing
 public class StreamingApplication {
 

--- a/streaming-api/src/main/java/semicolon/viewtist/controller/LiveStreamingController.java
+++ b/streaming-api/src/main/java/semicolon/viewtist/controller/LiveStreamingController.java
@@ -1,4 +1,4 @@
-package semicolon.viewtist.cotroller;
+package semicolon.viewtist.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -6,12 +6,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import semicolon.viewtist.liveStreaming.dto.request.LiveStreamingCreateRequest;
 import semicolon.viewtist.liveStreaming.dto.request.LiveStreamingUpdateRequest;
@@ -41,8 +43,10 @@ public class LiveStreamingController {
   @PreAuthorize("isAuthenticated()")
   @PutMapping("/{streamingId}")
   public ResponseEntity<String> updateLiveStreaming(@PathVariable Long streamingId,
-      @RequestBody LiveStreamingUpdateRequest liveStreamingUpdateRequest) {
-    liveStreamingService.updateLiveStreaming(streamingId, liveStreamingUpdateRequest);
+      @RequestBody LiveStreamingUpdateRequest liveStreamingUpdateRequest,
+      Authentication authentication) {
+    liveStreamingService.updateLiveStreaming(streamingId, liveStreamingUpdateRequest,
+        authentication);
     return ResponseEntity.ok("스트리밍이 업데이트 되었습니다.");
   }
 
@@ -63,9 +67,17 @@ public class LiveStreamingController {
 
   // 카테고리로 검색
   @GetMapping("/category")
-  public Page<LiveStreamingResponse> findLiveSteamingsByCategory(@RequestBody Category category,
+  public Page<LiveStreamingResponse> findLiveSteamingsByCategory(@RequestParam Category category,
       Pageable pageable) {
     return liveStreamingService.findLiveStreamingsByCategory(category, pageable);
   }
 
+  @PreAuthorize("isAuthenticated()")
+  @DeleteMapping("/{streamingId}")
+  public ResponseEntity<String> stopStreaming(@PathVariable Long streamingId,
+      Authentication authentication) {
+    liveStreamingService.stopStreaming(streamingId, authentication);
+    return ResponseEntity.ok("스트리밍이 종료되었습니다.");
+
+  }
 }

--- a/streaming-api/src/main/java/semicolon/viewtist/controller/NotifyController.java
+++ b/streaming-api/src/main/java/semicolon/viewtist/controller/NotifyController.java
@@ -1,0 +1,30 @@
+package semicolon.viewtist.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import semicolon.viewtist.sse.service.NotifyService;
+
+@RestController
+@RequestMapping("/api/notify")
+@RequiredArgsConstructor
+public class NotifyController {
+
+  private final NotifyService notifyService;
+
+
+  @PreAuthorize("isAuthenticated()")
+  @GetMapping(value = "/subscribe", produces = "text/event-stream")
+  public SseEmitter subscribe(Authentication authentication,
+      @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId)
+      throws JsonProcessingException {
+    return notifyService.subscribe(authentication, lastEventId);
+  }
+
+}

--- a/streaming-api/src/main/java/semicolon/viewtist/controller/NotifyController.java
+++ b/streaming-api/src/main/java/semicolon/viewtist/controller/NotifyController.java
@@ -1,6 +1,5 @@
 package semicolon.viewtist.controller;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
@@ -20,11 +19,10 @@ public class NotifyController {
 
 
   @PreAuthorize("isAuthenticated()")
-  @GetMapping(value = "/subscribe", produces = "text/event-stream")
-  public SseEmitter subscribe(Authentication authentication,
-      @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId)
-      throws JsonProcessingException {
-    return notifyService.subscribe(authentication, lastEventId);
+  @GetMapping(value = "/connect", produces = "text/event-stream")
+  public SseEmitter connect(Authentication authentication,
+      @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId) {
+    return notifyService.connect(authentication, lastEventId);
   }
 
 }


### PR DESCRIPTION
<!-- 제목은 ex) `[컨벤션] 제목` 으로 작성한다. ex) [feature] 결제 기능 -->

---

### 🌱 작업 사항

# Streaming

streaming 삭제 기능 구현 원래 있었는데 없어진거 같아서 구현했다.

```
 // 스트리밍 삭제
  public void stopStreaming(Long streamId, Authentication authentication) {
    LiveStreaming liveStreaming = liveStreamingFindById(streamId);
    if (!liveStreaming.getUser().getEmail().equals(authentication.getName())) {
      throw new UserException(ErrorCode.USER_NOT_MATCH);
    }
    liveStreamingRepository.delete(liveStreaming);
  }
```

간단한 삭제 매서드다 if문은 삭제하려는 유저가 시작한 유저와 다를 때 발생하는 에러이다.

# Subscribe

```
  public void subscribe(String streamerNickname, Authentication authentication) {

    User streamer = getUserByNickname(streamerNickname);

    User user = getUserByEmail(authentication.getName());

    if (subscribeRepository.existsByReceiverAndUser(streamerNickname, user.getNickname())) {
      throw new SubscribeException(ALREADY_EXISTS_SUBSCRIBE);
    }

    Subscribe subscribe = Subscribe.builder()
        .user(user.getNickname())
        .receiver(streamer.getNickname())
        .build();

    subscribeRepository.save(subscribe);
  }
```

구독을 눌렀을때 실행되는 로직이다.
이름을 바디로 받아서 구독 테이블에 구독한 사람과 받은사람 이렇게 저장 되어 있다.
저장은 닉네임으로 하였고, if문은 이미 테이블에 저장되어있으면 구독중이라는 에러를 반환한다.

```
public void unsubscribe(String streamerNickname, Authentication authentication) {

    User streamer = getUserByNickname(streamerNickname);

    User user = getUserByEmail(authentication.getName());

    subscribeRepository.deleteByReceiverAndUser(streamer.getNickname(), user.getNickname());
  }
```

구독을 취소하는 매서드 이다.

구독을 삭제할때 스트리머 닉네임과, 유저닉네임을 파라미터로 받아서 데이터베이스에서 삭제한다.

# Noftify


![image](https://github.com/se-mi-col-on/Viewtist_BE/assets/143856509/2bbb5d90-5e15-40ab-a1b3-f7cc64c2d877)


```
@Service
@RequiredArgsConstructor
@Slf4j
public class NotifyService {

(1)private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60;

  private final EmitterRepositoryImpl emitterRepository;
  private final NotifyRepository notifyRepository;
  private final UserRepository userRepository;

(2) public SseEmitter subscribe(Authentication authentication, String lastEventId) {
    User user = userRepository.findByEmail(authentication.getName())
        .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));

    String emitterId = user.getNickname();

    SseEmitter emitter = emitterRepository.save(emitterId, new SseEmitter(DEFAULT_TIMEOUT));
    emitter.onCompletion(() -> {
      log.info("Emitter completed. [emitterId={}]", emitterId);
      emitterRepository.delete(emitterId);
    });
    emitter.onTimeout(() -> {
      log.info("Emitter timeout. [emitterId={}]", emitterId);
      emitterRepository.delete(emitterId);
    });
(3) // 503 에러를 방지하기 위한 더미 이벤트 전송
    String eventId = makeTimeIncludeId(authentication.getName());
    sendNotification(emitter, eventId, emitterId,
        "EventStream Created. [userEmail=" + authentication.getName() + "]", TEST.toString());

(4) // 클라이언트가 미수신한 Event 목록이 존재할 경우 전송하여 Event 유실을 예방
    if (hasLostData(lastEventId)) {
      sendLostData(lastEventId, authentication.getName(), emitterId, emitter);
    }
    return emitter;
  }


  private String makeTimeIncludeId(String email) {
    return email + "_" + System.currentTimeMillis();
  }

(5)private void sendNotification(SseEmitter emitter, String eventId, String emitterId, Object data,
      String notificationType) {
    try {
      emitter.send(SseEmitter.event()
          .id(eventId)
          .name(notificationType)
          .data(data)
      );
    } catch (IOException exception) {
      emitterRepository.delete(emitterId);
    }
  }

(6)private boolean hasLostData(String lastEventId) {
    return !lastEventId.isEmpty();
  }

(7)private void sendLostData(String lastEventId, String userEmail, String emitterId,
      SseEmitter emitter) {
    Map<String, Object> eventCaches = emitterRepository.findAllEventCacheStartWithByUserEmail(
        String.valueOf(userEmail));
    eventCaches.entrySet().stream()
        .filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
        .forEach(entry -> {
          sendNotification(emitter, entry.getKey(), emitterId, entry.getValue(),
              VIEWTIST.toString());
        });
  }

(8)public void streamingNotifySend(String receiver, NotificationType notificationType,
      String content) {

    String eventId = receiver + "_" + System.currentTimeMillis();

    NotifyStreamingResponse response = NotifyStreamingResponse.builder()
        .receiverName(receiver)
        .notifyId(eventId)
        .content(content)
        .type(STREAMING.toString())
        .build();

(9) User receiverUser = userRepository.findByNickname(receiver)
        .orElseThrow(() -> new UserException(ErrorCode.USER_NOT_FOUND));

    notifyRepository.save(
        createNotification(receiverUser, notificationType, response.getContent()));

    emitterRepository.get(receiver).ifPresentOrElse(sseEmitter -> {
      try {
        sseEmitter.send(
            SseEmitter.event().id(eventId).name(String.valueOf(STREAMING))
                .data(response));
      } catch (IOException e) {
        emitterRepository.delete(receiver);
      }
(10) }, () -> log.info("[SseEmitter] {} SseEmitter Not Founded", receiver));
  }

  private Notify createNotification(User receiver, NotificationType notificationType,
      String content) {
    return Notify.builder()
        .receiver(receiver)
        .notificationType(notificationType)
        .content(content)
        .isRead(false)
        .build();
  }

}
```

1. 필드 선언: EmitterRepositoryImpl, NotifyRepository, UserRepository의 인스턴스를 final로 선언하여, 의존성 주입을 통해 사용합니다.
DEFAULT_TIMEOUT은 SSE 연결의 기본 타임아웃 시간을 설정합니다.
2. subscribe 메서드: 사용자가 이벤트를 구독하는 기능을 담당합니다. 인증된 사용자 정보와 마지막 이벤트 ID를 매개변수로 받아, 사용자의 이벤트 구독을 처리합니다.
사용자 정보를 검증하고, 사용자의 닉네임을 기반으로 SseEmitter 인스턴스를 생성 및 저장합니다.
3. SseEmitter의 onCompletion과 onTimeout 콜백을 설정하여, 이벤트 스트림 종료 및 타임아웃 시 레포지토리에서 해당 에미터를 삭제합니다.
503 에러 방지를 위한 더미 이벤트를 전송합니다.
4. 사용자가 미수신한 이벤트가 있을 경우, 해당 이벤트를 전송하여 유실을 방지합니다.
5. sendNotification 메서드: SseEmitter를 통해 알림을 전송하는 기능을 담당합니다. 이벤트 ID, 에미터 ID, 데이터, 알림 유형을 매개변수로 받습니다.
6. hasLostData 메서드: 사용자가 마지막으로 수신한 이벤트 ID를 기반으로 미수신 데이터가 있는지 확인합니다.
7. sendLostData 메서드: 미수신 이벤트 데이터를 사용자에게 전송합니다. 사용자 이메일을 기반으로 이벤트 캐시를 조회하여, 마지막 이벤트 ID 이후의 모든 이벤트를 사용자에게
전송합니다.
8. streamingNotifySend 메서드: 특정 사용자에게 스트리밍 알림을 전송합니다. 수신자, 알림 유형, 내용을 매개변수로 받아 처리합니다.
9. 수신자에 대한 사용자 정보를 검증하고, 알림을 생성하여 저장합니다.
10. 수신자의 SseEmitter가 존재할 경우, 알림을 전송합니다. 에미터가 없을 경우, 로그를 남깁니다.


```
 // 스트리밍 시작
  public LiveStreamingResponse startLiveStreaming(
      LiveStreamingCreateRequest liveStreamingCreateRequest,
      Authentication authentication) {
    User user = findByEmail(authentication);
    Optional<LiveStreaming> optionalLiveStreaming = liveStreamingRepository.findByUser(user);
    if (optionalLiveStreaming.isPresent()) {
      throw new LiveStreamingException(ErrorCode.ALREADY_LIVE_STREAMING);
    }

    LiveStreaming liveStreaming = liveStreamingCreateRequest.from(liveStreamingCreateRequest, user);
    liveStreamingRepository.save(liveStreaming);
    List<Subscribe> subscribeList = subscribeRepository.findByReceiver(user.getNickname());
    for (Subscribe subscribe : subscribeList) {
      notifyService.streamingNotifySend(subscribe.getUser(), NotificationType.STREAMING,
          user.getNickname() + " is start stremaing"
      );
      log.info(subscribe.getUser() + "에게 알림을 보냈습니다.");
    }
    return LiveStreamingResponse.from(liveStreaming);
  }

```

기존 스트리밍 시작 매서드에 알림을 추가로 보내는 로직을 추가했다.

구독자 테이블에서 자신을 구족한 사람들에게 for문을 활용해서 전부 알림을 보낸다.

알림을 받는 사람들은 `NotifyStreamingResponse`형태로 알림을 받는다.

```
 @PreAuthorize("isAuthenticated()")
  @GetMapping(value = "/subscribe", produces = "text/event-stream")
  public SseEmitter subscribe(Authentication authentication,
      @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId)
      throws JsonProcessingException {
    return notifyService.subscribe(authentication, lastEventId);
  }
```
Server-Sent Events(SSE)를 사용하여 클라이언트에 이벤트를 비동기적으로 전송하는 방법이다.

produces = "text/event-stream" 속성은 이 메소드가 SSE를 지원함을 나타냅니다.


---

### ❓ 리뷰 포인트

필요한 기능들이나 코드부분에서 괜찮은지 리뷰 부탁드립니다.

---

### 🦄 관련 이슈

테스트는 postman에서 테스트 해봤습니다.

<img width="1205" alt="스크린샷 2024-03-18 오후 5 52 42" src="https://github.com/se-mi-col-on/Viewtist_BE/assets/143856509/2e7b60b8-0809-4182-89fe-9b39cd28b8b9">


---