### PR TITLE
[# 48]Feature/chat room ssl을 적용하여 https와 wss 통신 가능하도록 기능 추가

### DIFF
--- a/chatting-api/src/main/java/semicolon/viewtist/ChattingApplication.java
+++ b/chatting-api/src/main/java/semicolon/viewtist/ChattingApplication.java
@@ -16,9 +16,11 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @EnableJpaAuditing
 @EnableJpaRepositories(basePackages = {"semicolon.viewtist.chatting.repository",
-    "semicolon.viewtist.jwt.repository", "semicolon.viewtist.user.repository", "semicolon.viewtist.sse.repository"})
+    "semicolon.viewtist.jwt.repository", "semicolon.viewtist.user.repository", "semicolon.viewtist.sse.repository"
+    ,"semicolon.viewtist.liveStreaming.repository"})
 @EntityScan(basePackages = {"semicolon.viewtist.chatting.entity",
-    "semicolon.viewtist.jwt.entity", "semicolon.viewtist.user.entity", "semicolon.viewtist.sse.entity"})
+    "semicolon.viewtist.jwt.entity", "semicolon.viewtist.user.entity", "semicolon.viewtist.sse.entity"
+,"semicolon.viewtist.liveStreaming.entity"})
 @SpringBootApplication(exclude = SecurityAutoConfiguration.class)
 public class ChattingApplication {
 

--- a/chatting-api/src/main/java/semicolon/viewtist/controller/ChatMessageController.java
+++ b/chatting-api/src/main/java/semicolon/viewtist/controller/ChatMessageController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,10 +19,7 @@ import semicolon.viewtist.service.ChatMessageService;
 @RequiredArgsConstructor
 public class ChatMessageController {
   private final ChatMessageService chatMessageService;
-  @MessageMapping("/message")
-  public void enter(ChatMessageRequest message) {
-    chatMessageService.sendChatMessage(message);
-  }
+  @PreAuthorize("isAuthenticated()")
   @GetMapping("/chat/{streamKey}")
   @Operation(summary = "입장시 이전의 채팅 내역을 불러온다.", description = "채팅방에 있는 채팅 내역들이 불러와짐")
   public ResponseEntity<List<ChatMessageResponse>> getChatMessageHistory(@PathVariable String streamKey){

--- a/chatting-api/src/main/java/semicolon/viewtist/controller/ChatRoomController.java
+++ b/chatting-api/src/main/java/semicolon/viewtist/controller/ChatRoomController.java
@@ -1,21 +1,14 @@
 package semicolon.viewtist.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Page;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import semicolon.viewtist.chatting.dto.request.ChatRoomRequest;
-import semicolon.viewtist.chatting.dto.response.ChatRoomResponse;
 import semicolon.viewtist.service.ChatRoomService;
 
 @RestController
@@ -23,23 +16,11 @@ import semicolon.viewtist.service.ChatRoomService;
 @RequiredArgsConstructor
 public class ChatRoomController {
   private final ChatRoomService chatRoomService;
-  // 스트리밍 시작시 채팅방 생성
-  @PostMapping("/chatroom")
-  @Operation(summary = "채팅방을 생성한다.", description = "처음 스트리밍을 시작할때 생성됨 status 자동으로 ON")
-  public ResponseEntity<String> createChatRoom(
-      @RequestBody ChatRoomRequest chatRoomRequest) throws Exception {
-    chatRoomService.createRoom(chatRoomRequest);
-    return ResponseEntity.ok("채팅방이 생성되었습니다.");
-  }
+  @PreAuthorize("isAuthenticated()")
   @PutMapping("/chatroom/{streamKey}")
-  @Operation(summary = "채팅방 상태를 설정한다.", description = "스트리밍 시작할때는 status = ON 종료할때는 status = OFF")
-  public ResponseEntity<String> enableChatRoom(@PathVariable String streamKey, String status) throws Exception {
+  @Operation(summary = "채팅방 상태를 설정한다.", description = "채팅금지 status = ON 채팅가능 status = OFF")
+  public ResponseEntity<String> enableChatRoom(@PathVariable String streamKey, String status, Authentication authentication) throws Exception {
 
-    return ResponseEntity.ok(chatRoomService.setChatRoomStatus(streamKey,status));
-  }
-  @GetMapping("/chatroom")
-  @Operation(summary = "현재 활성화된 채팅방을 조회한다.", description = "스트리밍방송이 켜져있는 채팅방 조회.")
-  public ResponseEntity<Page<ChatRoomResponse>> getAllChatroom(@PageableDefault Pageable pageable) throws Exception {
-    return ResponseEntity.ok(chatRoomService.findActivatedRoom(pageable));
+    return ResponseEntity.ok(chatRoomService.setChatRoomStatus(streamKey,status,authentication));
   }
 }

--- a/chatting-api/src/main/java/semicolon/viewtist/service/ChatMessageService.java
+++ b/chatting-api/src/main/java/semicolon/viewtist/service/ChatMessageService.java
@@ -5,6 +5,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import semicolon.viewtist.chatting.dto.request.ChatMessageRequest;
 import semicolon.viewtist.chatting.dto.request.ChatMessageRequest.MessageType;
 import semicolon.viewtist.chatting.dto.response.ChatMessageResponse;
@@ -13,6 +14,8 @@ import semicolon.viewtist.chatting.repository.ChatMessageRepository;
 import semicolon.viewtist.chatting.repository.ChatRoomRepository;
 import semicolon.viewtist.chatting.exception.ChattingException;
 import semicolon.viewtist.global.exception.ErrorCode;
+import semicolon.viewtist.user.entity.User;
+import semicolon.viewtist.user.repository.UserRepository;
 import semicolon.viewtist.websocket.WebSocketChatHandler;
 
 @Service
@@ -20,19 +23,9 @@ import semicolon.viewtist.websocket.WebSocketChatHandler;
 public class ChatMessageService {
   private final ChatMessageRepository chatMessageRepository;
   private final ChatRoomRepository chatRoomRepository;
-  private final WebSocketChatHandler webSocketChatHandler;
+  private UserRepository userRepository;
 
 
-  public void sendChatMessage(ChatMessageRequest message) {
-    chatRoomRepository.findByStreamKey(message.getStreamKey()).orElseThrow(
-        () -> new ChattingException(ErrorCode.NOT_EXIST_STREAMKEY)
-    );
-    if (MessageType.ENTER.equals(message.getMessageType())) {
-      message.setMessage(message.getSenderId()+"님이 입장하였습니다.");
-    }
-    chatMessageRepository.save(ChatMessage.from(message));
-   // webSocketChatHandler.sendMessage();
-  }
   // 이전 채팅 메세지 내역
   public List<ChatMessageResponse> getChatMessages(String streamKey){
     return chatMessageRepository.findByStreamKeyOrderByCreatedAtDesc(streamKey)

--- a/chatting-api/src/main/java/semicolon/viewtist/service/ChatRoomService.java
+++ b/chatting-api/src/main/java/semicolon/viewtist/service/ChatRoomService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import semicolon.viewtist.chatting.dto.request.ChatRoomRequest;
@@ -13,30 +14,28 @@ import semicolon.viewtist.chatting.entity.type.Status;
 import semicolon.viewtist.chatting.repository.ChatRoomRepository;
 import semicolon.viewtist.chatting.exception.ChattingException;
 import semicolon.viewtist.global.exception.ErrorCode;
+import semicolon.viewtist.user.entity.User;
+import semicolon.viewtist.user.exception.UserException;
+import semicolon.viewtist.user.repository.UserRepository;
 
 @Slf4j
 @RequiredArgsConstructor
 @Service
 public class ChatRoomService {
   private final ChatRoomRepository chatRoomRepository;
-
-  @Transactional
-  public void createRoom(ChatRoomRequest request) {
-    if(chatRoomRepository.existsByStreamKey(request.getStreamKey())){
-      throw new ChattingException(ErrorCode.ALREADY_EXIST_STREAMKEY);
-    }
-    if(chatRoomRepository.existsByStreamerId(request.getStreamerId())){
-      throw new ChattingException(ErrorCode.ALREADY_CREATE_ANOTHER_ROOM);
-    }
-    ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.from(request));
-    setStatus(chatRoom,true);
-  }
+  private final UserRepository userRepository;
   // 채팅방 상태 설정
   @Transactional
-  public String setChatRoomStatus(String streamKey, String status) {
+  public String setChatRoomStatus(String streamKey, String status, Authentication authentication) {
     ChatRoom chatRoom = chatRoomRepository.findByStreamKey(streamKey).orElseThrow(
         () -> new ChattingException(ErrorCode.NOT_EXIST_STREAMKEY)
     );
+    User user = userRepository.findByEmail(authentication.getName()).orElseThrow(
+        () -> new UserException(ErrorCode.ALREADY_EXISTS_EMAIL)
+    );
+    if(!user.getId().equals(chatRoom.getStreamerId())){
+        throw new UserException(ErrorCode.ACCESS_DENIED);
+    }
     if(status.equals(Status.ON.toString())){
       setStatus(chatRoom,true);
     }else{
@@ -46,9 +45,5 @@ public class ChatRoomService {
   }
   private void setStatus(ChatRoom chatRoom, boolean status){
     chatRoom.setChatRoomActivate(status);
-  }
-  public Page<ChatRoomResponse> findActivatedRoom(Pageable pageable) {
-    Page<ChatRoom> activatedRooms = chatRoomRepository.findByActiveIsTrue(pageable);
-    return activatedRooms.map(ChatRoomResponse::from);
   }
 }

--- a/chatting-api/src/main/java/semicolon/viewtist/websocket/WebSocketChatHandler.java
+++ b/chatting-api/src/main/java/semicolon/viewtist/websocket/WebSocketChatHandler.java
@@ -30,8 +30,7 @@ public class WebSocketChatHandler extends TextWebSocketHandler {
   private final ObjectMapper mapper;
   private final Set<WebSocketSession> sessions = new HashSet<>();
   private final Map<String,Set<WebSocketSession>> chatRoomSessionMap = new HashMap<>();
-  private UserRepository userRepository;
-  private ChatMessageService chatMessageService;
+  private final UserRepository userRepository;
 
 // 스트리밍을 시청할때 채팅방 접속
   @Override

--- a/common/src/main/java/semicolon/viewtist/user/service/AuthService.java
+++ b/common/src/main/java/semicolon/viewtist/user/service/AuthService.java
@@ -35,8 +35,6 @@ import semicolon.viewtist.user.repository.UserRepository;
 @Service
 @RequiredArgsConstructor
 public class AuthService {
-
-
   private final RefreshTokenRepository refreshTokenRepository;
   private final TokenBlacklistRepository tokenBlacklistRepository;
   private final MailgunClient mailgunClient;

--- a/domain/src/main/java/semicolon/viewtist/chatting/dto/response/ChatRoomResponse.java
+++ b/domain/src/main/java/semicolon/viewtist/chatting/dto/response/ChatRoomResponse.java
@@ -18,7 +18,6 @@ public class ChatRoomResponse {
 
   public static ChatRoomResponse from(ChatRoom chatroom) {
     return ChatRoomResponse.builder()
-        .streamKey(chatroom.getStreamKey())
         .streamerId(chatroom.getStreamerId())
         .build();
   }

--- a/domain/src/main/java/semicolon/viewtist/chatting/entity/ChatRoom.java
+++ b/domain/src/main/java/semicolon/viewtist/chatting/entity/ChatRoom.java
@@ -1,8 +1,7 @@
 package semicolon.viewtist.chatting.entity;
 
-import jakarta.persistence.CascadeType;
+
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -12,7 +11,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import semicolon.viewtist.chatting.dto.request.ChatRoomRequest;
 import semicolon.viewtist.global.entitiy.BaseTimeEntity;
 import semicolon.viewtist.liveStreaming.entity.LiveStreaming;
 import semicolon.viewtist.user.entity.User;

--- a/domain/src/main/java/semicolon/viewtist/chatting/entity/ChatRoom.java
+++ b/domain/src/main/java/semicolon/viewtist/chatting/entity/ChatRoom.java
@@ -1,15 +1,21 @@
 package semicolon.viewtist.chatting.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import semicolon.viewtist.chatting.dto.request.ChatRoomRequest;
 import semicolon.viewtist.global.entitiy.BaseTimeEntity;
+import semicolon.viewtist.liveStreaming.entity.LiveStreaming;
+import semicolon.viewtist.user.entity.User;
 
 @Getter
 @AllArgsConstructor
@@ -21,20 +27,30 @@ public class ChatRoom extends BaseTimeEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
-  private String streamKey;
+
+  @OneToOne
+  @JoinColumn(name="streaming_id")
+  private LiveStreaming streaming;
   private Long streamerId;
+  private String streamKey;
   private boolean active;
 
-  public static ChatRoom from(ChatRoomRequest request) {
+
+  public static ChatRoom madeByUser(User user) {
     return ChatRoom.builder()
-        .streamKey(request.getStreamKey())
-        .streamerId(request.getStreamerId())
+        .streamerId(user.getId())
+        .streamKey(user.getStreamKey())
+        .active(true)
         .build();
   }
+
   public void setChatRoomActivate(boolean status){
     this.active = status;
   }
   public boolean isActive(){
     return active;
+  }
+  public void createdByStreaming(LiveStreaming liveStreaming){
+    this.streaming = liveStreaming;
   }
 }

--- a/domain/src/main/java/semicolon/viewtist/chatting/repository/ChatRoomRepository.java
+++ b/domain/src/main/java/semicolon/viewtist/chatting/repository/ChatRoomRepository.java
@@ -15,4 +15,5 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
   Page<ChatRoom> findByActiveIsTrue(Pageable pageable);
 
+  Optional<ChatRoom> findByStreamKey(String streamKey);
 }

--- a/domain/src/main/java/semicolon/viewtist/chatting/repository/ChatRoomRepository.java
+++ b/domain/src/main/java/semicolon/viewtist/chatting/repository/ChatRoomRepository.java
@@ -11,11 +11,8 @@ import semicolon.viewtist.chatting.entity.ChatRoom;
 @Repository
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
-  boolean existsByStreamKey(String streamKey);
   boolean existsByStreamerId(Long streamerId);
-  boolean findByStreamKeyAndActiveIsTrue(String streamKey);
 
   Page<ChatRoom> findByActiveIsTrue(Pageable pageable);
 
-  Optional<ChatRoom> findByStreamKey(String streamKey);
 }

--- a/domain/src/main/java/semicolon/viewtist/liveStreaming/dto/request/LiveStreamingCreateRequest.java
+++ b/domain/src/main/java/semicolon/viewtist/liveStreaming/dto/request/LiveStreamingCreateRequest.java
@@ -12,7 +12,6 @@ import semicolon.viewtist.user.entity.User;
 public class LiveStreamingCreateRequest {
 
   private String title;
-
   private Category category;
 
 
@@ -21,6 +20,7 @@ public class LiveStreamingCreateRequest {
         .title(liveStreamingCreateRequest.getTitle())
         .user(user)
         .category(liveStreamingCreateRequest.getCategory())
+        .viewerCount(0L)
         .startAt(LocalDateTime.now())
         .build();
   }

--- a/domain/src/main/java/semicolon/viewtist/liveStreaming/dto/response/LiveStreamingResponse.java
+++ b/domain/src/main/java/semicolon/viewtist/liveStreaming/dto/response/LiveStreamingResponse.java
@@ -24,6 +24,8 @@ public class LiveStreamingResponse {
 
   private Long viewerCount;
 
+  private Long chattingRoomId;
+
 
   public static LiveStreamingResponse from(LiveStreaming liveStreaming) {
     return LiveStreamingResponse.builder()

--- a/domain/src/main/java/semicolon/viewtist/liveStreaming/dto/response/LiveStreamingResponse.java
+++ b/domain/src/main/java/semicolon/viewtist/liveStreaming/dto/response/LiveStreamingResponse.java
@@ -24,7 +24,6 @@ public class LiveStreamingResponse {
 
   private Long viewerCount;
 
-  private Long chattingRoomId;
 
 
   public static LiveStreamingResponse from(LiveStreaming liveStreaming) {
@@ -33,6 +32,7 @@ public class LiveStreamingResponse {
         .title(liveStreaming.getTitle())
         .streamerNickname(liveStreaming.getUser().getNickname())
         .category(liveStreaming.getCategory())
+        .viewerCount(liveStreaming.getViewerCount())
         .startAt(liveStreaming.getStartAt())
         .build();
   }

--- a/domain/src/main/java/semicolon/viewtist/liveStreaming/entity/LiveStreaming.java
+++ b/domain/src/main/java/semicolon/viewtist/liveStreaming/entity/LiveStreaming.java
@@ -1,18 +1,22 @@
 package semicolon.viewtist.liveStreaming.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import semicolon.viewtist.chatting.entity.ChatRoom;
 import semicolon.viewtist.global.entitiy.BaseTimeEntity;
 import semicolon.viewtist.liveStreaming.dto.request.LiveStreamingUpdateRequest;
 import semicolon.viewtist.liveStreaming.dto.response.LiveStreamingResponse;
@@ -45,6 +49,9 @@ public class LiveStreaming extends BaseTimeEntity {
   @Column
   private Long viewerCount;
 
+  @OneToOne(mappedBy = "streaming",fetch = FetchType.LAZY,cascade = CascadeType.ALL)
+  private ChatRoom chatRoom;
+
   public LiveStreamingResponse form(LiveStreaming liveStreaming) {
     return LiveStreamingResponse.builder()
         .title(liveStreaming.getTitle())
@@ -58,5 +65,10 @@ public class LiveStreaming extends BaseTimeEntity {
   public void update(LiveStreamingUpdateRequest liveStreamingUpdateRequest) {
     this.title = liveStreamingUpdateRequest.getUpdateTitle();
     this.category = liveStreamingUpdateRequest.getUpdateCategory();
+  }
+
+  public void createChatRoom(ChatRoom chatRoom){
+    this.chatRoom = chatRoom;
+    chatRoom.createdByStreaming(this);
   }
 }

--- a/domain/src/main/java/semicolon/viewtist/liveStreaming/entity/LiveStreaming.java
+++ b/domain/src/main/java/semicolon/viewtist/liveStreaming/entity/LiveStreaming.java
@@ -52,7 +52,7 @@ public class LiveStreaming extends BaseTimeEntity {
   @OneToOne(mappedBy = "streaming",fetch = FetchType.LAZY,cascade = CascadeType.ALL)
   private ChatRoom chatRoom;
 
-  public LiveStreamingResponse form(LiveStreaming liveStreaming) {
+  public LiveStreamingResponse from(LiveStreaming liveStreaming) {
     return LiveStreamingResponse.builder()
         .title(liveStreaming.getTitle())
         .streamerNickname(liveStreaming.getUser().getNickname())

--- a/domain/src/main/java/semicolon/viewtist/user/entity/User.java
+++ b/domain/src/main/java/semicolon/viewtist/user/entity/User.java
@@ -57,6 +57,8 @@ public class User extends BaseTimeEntity {
   @Column
   private String channelIntroduction;
 
+  @Column
+  private String sessionId;
 
   public void setEmailVerified(boolean emailVerified, String emailVerificationToken) {
     isEmailVerified = emailVerified;
@@ -93,5 +95,8 @@ public class User extends BaseTimeEntity {
 
   public void setChannelIntroduction(String updateIntroduction) {
     this.channelIntroduction = updateIntroduction;
+  }
+  public void setSessionId(String sessionId){
+    this.sessionId = sessionId;
   }
 }

--- a/domain/src/main/java/semicolon/viewtist/user/repository/UserRepository.java
+++ b/domain/src/main/java/semicolon/viewtist/user/repository/UserRepository.java
@@ -2,8 +2,9 @@ package semicolon.viewtist.user.repository;
 
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 import semicolon.viewtist.user.entity.User;
-
+@Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
   boolean existsByEmail(String email);

--- a/streaming-api/src/main/java/semicolon/viewtist/LiveStreamingApplication.java
+++ b/streaming-api/src/main/java/semicolon/viewtist/LiveStreamingApplication.java
@@ -10,10 +10,10 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 @SpringBootApplication
 @EnableJpaRepositories(basePackages = {"semicolon.viewtist.liveStreaming.repository",
     "semicolon.viewtist.user.repository", "semicolon.viewtist.jwt.repository",
-    "semicolon.viewtist.sse.repository"})
+    "semicolon.viewtist.sse.repository","semicolon.viewtist.chatting.repository"})
 @EntityScan(basePackages = {"semicolon.viewtist.liveStreaming.entity",
     "semicolon.viewtist.user.entity", "semicolon.viewtist.jwt.entity",
-    "semicolon.viewtist.sse.entity"})
+    "semicolon.viewtist.sse.entity","semicolon.viewtist.chatting.entity"})
 @EnableJpaAuditing
 public class LiveStreamingApplication {
 

--- a/streaming-api/src/main/java/semicolon/viewtist/service/LiveStreamingService.java
+++ b/streaming-api/src/main/java/semicolon/viewtist/service/LiveStreamingService.java
@@ -8,6 +8,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import semicolon.viewtist.chatting.entity.ChatRoom;
+import semicolon.viewtist.chatting.exception.ChattingException;
+import semicolon.viewtist.chatting.repository.ChatRoomRepository;
 import semicolon.viewtist.global.exception.ErrorCode;
 import semicolon.viewtist.liveStreaming.dto.request.LiveStreamingCreateRequest;
 import semicolon.viewtist.liveStreaming.dto.request.LiveStreamingUpdateRequest;
@@ -28,13 +32,14 @@ import semicolon.viewtist.user.repository.UserRepository;
 @RequiredArgsConstructor
 @Slf4j
 public class LiveStreamingService {
-
   private final LiveStreamingRepository liveStreamingRepository;
   private final UserRepository userRepository;
   private final NotifyService notifyService;
   private final SubscribeRepository subscribeRepository;
+  private final ChatRoomRepository chatRoomRepository;
 
   // 스트리밍 시작
+  @Transactional
   public LiveStreamingResponse startLiveStreaming(
       LiveStreamingCreateRequest liveStreamingCreateRequest,
       Authentication authentication) {
@@ -43,9 +48,19 @@ public class LiveStreamingService {
     if (optionalLiveStreaming.isPresent()) {
       throw new LiveStreamingException(ErrorCode.ALREADY_LIVE_STREAMING);
     }
+    // 스트리밍 생성
+    LiveStreaming liveStreaming =
+      liveStreamingRepository.save(liveStreamingCreateRequest.from(liveStreamingCreateRequest, user));
 
-    LiveStreaming liveStreaming = liveStreamingCreateRequest.from(liveStreamingCreateRequest, user);
-    liveStreamingRepository.save(liveStreaming);
+
+    if(chatRoomRepository.existsByStreamerId(user.getId())){
+      throw new ChattingException(ErrorCode.ALREADY_CREATE_ANOTHER_ROOM);
+    }
+    // 채팅방 생성
+    ChatRoom chatRoom =
+        chatRoomRepository.save(ChatRoom.madeByUser(user));
+    liveStreaming.createChatRoom(chatRoom);
+
     List<Subscribe> subscribeList = subscribeRepository.findByReceiver(user.getNickname());
     for (Subscribe subscribe : subscribeList) {
       notifyService.streamingNotifySend(subscribe.getUser(), NotificationType.STREAMING,

--- a/streaming-api/src/main/java/semicolon/viewtist/service/LiveStreamingService.java
+++ b/streaming-api/src/main/java/semicolon/viewtist/service/LiveStreamingService.java
@@ -51,16 +51,22 @@ public class LiveStreamingService {
     // 스트리밍 생성
     LiveStreaming liveStreaming =
       liveStreamingRepository.save(liveStreamingCreateRequest.from(liveStreamingCreateRequest, user));
+    // 채팅방 생성
+   createChatRoom(user,liveStreaming);
+    // 알림전송
+    sendAlarmToSubscriber(user);
+    return LiveStreamingResponse.from(liveStreaming);
+  }
 
-
+  private void createChatRoom(User user, LiveStreaming liveStreaming){
     if(chatRoomRepository.existsByStreamerId(user.getId())){
       throw new ChattingException(ErrorCode.ALREADY_CREATE_ANOTHER_ROOM);
     }
-    // 채팅방 생성
     ChatRoom chatRoom =
         chatRoomRepository.save(ChatRoom.madeByUser(user));
     liveStreaming.createChatRoom(chatRoom);
-
+  }
+  private void sendAlarmToSubscriber(User user){
     List<Subscribe> subscribeList = subscribeRepository.findByReceiver(user.getNickname());
     for (Subscribe subscribe : subscribeList) {
       notifyService.streamingNotifySend(subscribe.getUser(), NotificationType.STREAMING,
@@ -68,7 +74,6 @@ public class LiveStreamingService {
       );
       log.info(subscribe.getUser() + "에게 알림을 보냈습니다.");
     }
-    return LiveStreamingResponse.from(liveStreaming);
   }
 
   // 스트리밍 업데이트


### PR DESCRIPTION
<!-- 제목은 ex) `[컨벤션] 제목` 으로 작성한다. ex) [feature] 결제 기능 -->

---

# 🌱 작업 사항

<!-- ex) controller 코딩 했어요 -->
## https 설정
기존 배포된 서버는 `http` 통신을 하였고 `ws` 통신은 불가능했다. 
찾아보니 `https` 위에서 `wss` 연결을 해야 웹소켓 통신이 정상 작동한다고 한다.

### SSL
https 통신을 하기 위해서는 기관에서 인증한 SSL 인증서가 필요하다.
인증서는 2개의 종류가 있다.

#### 기관에서 인증한 인증서
1. 도메인 구매 
2. cerbot 설치 
3. 도메인에 대한 인증서 발급 
4. 자바가 인식할 수 있도록 .p12 로 확장자 변경
  
####  ✅ 사설에서 인증한 인증서 (이 방법으로 진행)
1. 로컬에서 키 생성
2. `keytool -genkey -alias spring -storetype PKCS12 -keyalg RSA -keysize 2048 -keystore keystore.p12 -validity 4000 `
3. keystore를 resources 파일에 저장
4. application.yml에 keystore에 대한 정보를 적어준다. 
<img width="338" alt="image" src="https://github.com/se-mi-col-on/Viewtist_BE/assets/129943670/b9ec7183-002f-410e-8e6e-7ffdb448ceb0">

## 웹소켓 연결 확인
<img width="920" alt="image" src="https://github.com/se-mi-col-on/Viewtist_BE/assets/129943670/b9d1d61e-6c77-4e64-935c-c48f38105a77">

## 채팅방 생성
스트리밍 시작시 스트리밍 엔티티가 생성될 때 채팅방도 함께 생성
스트리밍 종료 시 스트리밍 엔티티가 삭제될 때 채팅방도 함께 삭제

## 포트 리다이렉트
ChattingApplication 8081 포트로 들어온 요청은 443 포트로 리다이렉트하도록 설정
도커 역시 443:443 포트를 추가하여 https 통신이 가능하도록 변경

---

### ❓ 리뷰 포인트
스트리밍과 채팅방은 1:1 연관관계로 매핑
의존관계의 주인은 스트리밍으로 설정하여 스트리밍의 변경사항을 모두 채팅방에 전이시킴
기존의 스트리밍 시작 메서드에 포함된 기능(채팅방 생성, 알림 전송)을 private method로 분리시켰다.

<!-- ex) service 로직 너무 뚱뚱해요 -->

---

### 🦄 관련 이슈
chatting만 https인게 좀 어색(?)하다는 생각이 듭니다.
추후에 (시간될때) aws elb로 ssl 적용시켜보고싶네요.

<!-- ex) 테스트 어떤가요. -->

---
